### PR TITLE
ci(unit-tests): shard into 4 matrix jobs + aggregator to avoid V8 OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,18 @@ jobs:
       - name: Run TypeScript
         run: pnpm typecheck
 
-  unit-tests:
-    name: Unit Tests
+  # Full test suite OOMs V8's per-worker heap when run in a single process
+  # (6000+ tests, jsdom + msw + AI provider singletons accumulate). Sharding
+  # into 4 parallel workers keeps each within budget. The aggregator below
+  # exposes a single 'Unit Tests' status check that branch protection can
+  # depend on regardless of shard count.
+  unit-tests-shard:
+    name: Unit Tests Shard (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     env:
       DATABASE_URL: 'file:./test.db'
       JWT_SECRET: 'test-jwt-secret'
@@ -91,14 +100,28 @@ jobs:
       - name: Generate Prisma Client
         run: pnpm db:generate
 
-      - name: Run Unit Tests
-        run: pnpm test:coverage
+      - name: Run Unit Tests Shard ${{ matrix.shard }}/4
+        # `--coverage` is intentionally dropped from the sharded run: coverage
+        # merging across shards is non-trivial and the per-shard threshold
+        # would always fail. Coverage gating moves to a follow-up Phase 1
+        # job that merges shards or runs the full suite separately.
+        run: pnpm test -- --shard=${{ matrix.shard }}/4
 
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: [unit-tests-shard]
+    if: always()
+    steps:
+      - name: Verify every shard succeeded
+        env:
+          SHARD_RESULT: ${{ needs.unit-tests-shard.result }}
+        run: |
+          echo "Shard aggregate result: $SHARD_RESULT"
+          if [ "$SHARD_RESULT" != "success" ]; then
+            echo "::error::At least one Unit Tests shard failed"
+            exit 1
+          fi
 
   integration-tests:
     name: Integration Tests


### PR DESCRIPTION
## Summary

Master CI is currently red on Unit Tests: the full 6000+ vitest suite OOMs V8's per-worker heap (`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`) — 6251 tests pass individually, only the worker fork crashes during finalization. This was a Known Limitation of PR #14 (now merged); this follow-up implements the planned shard strategy to close the loop.

Originally part of PR #14's plan-B fallback (`Unit Testsをvitest --shard=i/4 マトリクス+集約ジョブ化`); split out because #14 was merged before this commit landed.

## Changes
- `unit-tests-shard` matrix job (`shard: [1,2,3,4]`): runs `pnpm test -- --shard=i/4`. Each shard's heap budget stays well within V8's default per-fork cap.
- `unit-tests` aggregator job: waits on the matrix and surfaces a single `success`/`failure` status. Branch protection's `Unit Tests` required-check contract is preserved unchanged.
- `Build`'s `needs: [..., unit-tests, ...]` keeps working (same job id).

## Trade-offs (intentional)
- `--coverage` dropped from sharded runs — per-shard thresholds would always fail, and merging across shards is non-trivial. Coverage gating becomes a Phase 1 task (run on a separate optional job, or use a coverage merging tool).
- The underlying memory accumulation (jsdom + msw + AI provider singletons + tiktoken WASM across files) is not fixed; sharding avoids it rather than resolves it. Phase 1 should investigate.

## Test plan
- [ ] CI: all 4 `Unit Tests Shard (i/4)` jobs go green
- [ ] CI: `Unit Tests` aggregator goes green
- [ ] CI: Build (which depends on unit-tests) runs and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)