### PR TITLE
ci(unit-tests): widen to 8 shards + NODE_OPTIONS=6144 (follow-up to #15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,17 +68,21 @@ jobs:
   # exposes a single 'Unit Tests' status check that branch protection can
   # depend on regardless of shard count.
   unit-tests-shard:
-    name: Unit Tests Shard (${{ matrix.shard }}/4)
+    name: Unit Tests Shard (${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     env:
       DATABASE_URL: 'file:./test.db'
       JWT_SECRET: 'test-jwt-secret'
       ENCRYPTION_KEY: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
       CSRF_SECRET: 'test-csrf-secret'
+      # Vitest's worker fork inherits this; raises the per-worker heap from
+      # V8's ~4 GB default. Combined with 8 shards, each fork stays well
+      # under the cap throughout the run.
+      NODE_OPTIONS: '--max-old-space-size=6144'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,12 +104,12 @@ jobs:
       - name: Generate Prisma Client
         run: pnpm db:generate
 
-      - name: Run Unit Tests Shard ${{ matrix.shard }}/4
+      - name: Run Unit Tests Shard ${{ matrix.shard }}/8
         # `--coverage` is intentionally dropped from the sharded run: coverage
         # merging across shards is non-trivial and the per-shard threshold
         # would always fail. Coverage gating moves to a follow-up Phase 1
         # job that merges shards or runs the full suite separately.
-        run: pnpm test -- --shard=${{ matrix.shard }}/4
+        run: pnpm test -- --shard=${{ matrix.shard }}/8
 
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
## Summary

Follow-up to PR #15: 4 shards still hit V8 OOM (each shard reached ~4070 MB / ~4 GB cap). This PR doubles to 8 shards and raises NODE_OPTIONS=--max-old-space-size=6144 for a 50% headroom buffer.

Master CI is currently red on Unit Tests until this lands.

## Change
- `unit-tests-shard` matrix: `[1..8]` (was `[1..4]`)
- `env.NODE_OPTIONS: '--max-old-space-size=6144'` added to the shard job
- Aggregator `unit-tests` job unchanged (required-check contract preserved)

## Test plan
- [ ] All 8 `Unit Tests Shard (i/8)` jobs go green
- [ ] `Unit Tests` aggregator goes green
- [ ] `Build` (depends on `unit-tests`) runs and passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)