### PR TITLE
test: verify CodeOwner gate on src/lib/auth/

### DIFF
--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -18,3 +18,5 @@ export {
   type TokenRotationResult,
   type TokenLifecycleConfig,
 } from './token-lifecycle'
+
+// CodeOwner gate verification probe (no-op).


### PR DESCRIPTION
## Summary
1-line no-op change to `src/lib/auth/index.ts` (CODEOWNERS-owned) to verify that branch protection blocks merge until a code owner approves.

## Expected behavior
- CI: Lint / Type Check / Unit Tests / Build all pass
- Merge: **blocked** with "Required: 1 code owner approval" until @mizunotaro approves the file

This validates the require_code_owner_reviews gate end-to-end.

To revert after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)