### PR TITLE
[auto/C] auto(C): Unit-test coverage: report + reports + export + import

### DIFF
--- a/docs/auto-sessions/cov-svc-06/summary.md
+++ b/docs/auto-sessions/cov-svc-06/summary.md
@@ -1,0 +1,72 @@
+# COV-SVC-06 — Unit-test coverage: report + reports + export + import
+
+## Outcome
+
+Added 7 new additive test files (93 real-assertion tests) covering exported
+functions under `src/services/report`, `src/services/reports`, `src/services/export`,
+and `src/services/import` that previously had no mirror test.
+
+Verify gate: `node scripts/autopm_verify.mjs --changed-only` → **exit 0**
+(typecheck 0 relevant errors, eslint `--max-warnings=0` clean, vitest 93/93 passed).
+
+## Gap analysis (exports lacking a mirror test)
+
+Cross-checked every runtime export in the four target areas against the test
+corpus under `tests/unit`. Already-covered modules were left untouched:
+`report/cash-flow.ts` (root `report.test.ts`), `report/monthly-report.ts`,
+`report/periodic-report.ts`, `export/{pdf,pptx,excel}-export.ts`,
+`import/{base,account-item,journal,journal-importer,monthly-balance}-importer.ts`,
+`import/parsers/*`, `import/ai/*`, and `reports/business-report/*` were all
+already exercised.
+
+Genuine gaps filled:
+
+| # | Source module | Untested exports | New test file |
+|---|---------------|------------------|---------------|
+| 1 | `export/types.ts` | `DEFAULT_EXPORT_OPTIONS`, `MIME_TYPES`, `FILE_EXTENSIONS` | `tests/unit/services/export/export-types.test.ts` |
+| 2 | `export/index.ts` | `createExportService` | `tests/unit/services/export/export-service.test.ts` |
+| 3 | `import/types.ts` | `IMPORT_LIMITS`, `DEFAULT_IMPORT_OPTIONS`, `SUPPORTED_FILE_TYPES`, `IMPORT_ERROR_MESSAGES`, `getErrorMessage`, `IMPORT_CONFIG_VERSION` | `tests/unit/services/import/import-types.test.ts` |
+| 4 | `reports/ir/ir-report-service.ts` | 14 localStorage functions + `irReportService` | `tests/unit/services/reports/ir/ir-report-service.test.ts` |
+| 5 | `reports/ir-shareholder-service.ts` | `getShareholderCompositions`, `upsertShareholderComposition`, `deleteShareholderComposition`, `getLatestShareholderComposition` | `tests/unit/services/reports/ir-shareholder-service-extended.test.ts` |
+| 6 | `reports/ir-faq-service.ts` | `getActiveFAQs` | `tests/unit/services/reports/ir-faq-service-extended.test.ts` |
+| 7 | `reports/ir-event-service.ts` | `getUpcomingIREvents` | `tests/unit/services/reports/ir-event-service-extended.test.ts` |
+
+## Approach
+
+- Pure logic tested directly (export constants, `createExportService` dispatch,
+  `getErrorMessage` fallback, import limits/options).
+- `reports/ir/ir-report-service.ts` (client localStorage service) tested against
+  the real jsdom `localStorage`, cleared per-test. `generateSectionContent` uses
+  fake timers with the safe resolve-only pattern
+  (`const p = fn(); await vi.advanceTimersByTimeAsync(500); await p`) — it never
+  rejects, so the known async-rejection worker-crash pattern does not apply.
+- DB-backed IR services tested at the prisma boundary with a per-file
+  `vi.mock('@/lib/db', …)` plus a typed `MockDb` cast
+  (`prisma as unknown as MockDb`) so model-method mocks accept arbitrary fixture
+  shapes without `any` and without fighting Prisma's strict generated return types.
+
+## Findings / pre-existing debt (not modified — left as-is)
+
+The existing IR service test files
+(`ir-shareholder-service.test.ts`, `ir-faq-service.test.ts`,
+`ir-event-service.test.ts`) do **not** import the real services. Each defines its
+own local re-implementation of the functions inside the test file and asserts
+against those locals. The local re-implementations diverge from the real services
+(e.g. different required-field validation, different function names), so they are
+effectively fake-green for the real modules. The new `-extended` files import and
+exercise the **real** exports. Rewriting the existing fake-green files was
+deliberately **not** done: it is out of scope for an additive coverage task and
+would risk disturbing currently-passing tests; flagged here for a separate fix.
+
+## Not done (stated plainly)
+
+- The `typeof window === 'undefined'` server-guard branches in
+  `reports/ir/ir-report-service.ts` are not tested — jsdom always defines
+  `window`, and exercising them requires deleting the global `window`, which is
+  risky in this environment. They are trivial guards; skipped intentionally.
+- No source files were modified (additive-only). No Class-A path touched.
+
+## Constraints honoured
+
+No `any` / `@ts-ignore` / `@ts-expect-error` / `.skip` / lint-disable / coverage
+threshold change. No new dependencies. Only the added test files were run.

--- a/tests/unit/services/export/export-service.test.ts
+++ b/tests/unit/services/export/export-service.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { createExportService } from '@/services/export'
+import type { ExportFormat } from '@/services/export'
+
+describe('createExportService', () => {
+  it('returns a PDF service for the pdf format', () => {
+    const service = createExportService('pdf')
+
+    expect(typeof service.export).toBe('function')
+    expect(service.getSupportedFormats()).toEqual(['pdf'])
+  })
+
+  it('returns a PPTX service for the pptx format', () => {
+    const service = createExportService('pptx')
+
+    expect(service.getSupportedFormats()).toEqual(['pptx'])
+  })
+
+  it('returns an Excel service for the excel format', () => {
+    const service = createExportService('excel')
+
+    expect(service.getSupportedFormats()).toEqual(['excel', 'csv'])
+  })
+
+  it('routes csv to the Excel service', () => {
+    const service = createExportService('csv')
+
+    expect(service.getSupportedFormats()).toEqual(['excel', 'csv'])
+  })
+
+  it('exposes an export function on every supported service', () => {
+    const formats: ExportFormat[] = ['pdf', 'pptx', 'excel', 'csv']
+
+    for (const format of formats) {
+      expect(typeof createExportService(format).export).toBe('function')
+    }
+  })
+
+  it('throws for an unsupported format', () => {
+    expect(() => createExportService('docx' as ExportFormat)).toThrow(/Unsupported export format/)
+  })
+})

--- a/tests/unit/services/export/export-types.test.ts
+++ b/tests/unit/services/export/export-types.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_EXPORT_OPTIONS,
+  MIME_TYPES,
+  FILE_EXTENSIONS,
+  type ExportFormat,
+} from '@/services/export/types'
+
+describe('DEFAULT_EXPORT_OPTIONS', () => {
+  it('provides sensible defaults for a Japanese PDF export', () => {
+    expect(DEFAULT_EXPORT_OPTIONS).toEqual({
+      format: 'pdf',
+      language: 'ja',
+      currency: 'JPY',
+      includeCharts: true,
+      paperSize: 'A4',
+      orientation: 'landscape',
+    })
+  })
+
+  it('does not pin an exchange rate by default', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.exchangeRate).toBeUndefined()
+  })
+
+  it('uses a valid ExportFormat value', () => {
+    const formats: ExportFormat[] = ['pdf', 'pptx', 'excel', 'csv']
+    expect(formats).toContain(DEFAULT_EXPORT_OPTIONS.format)
+  })
+})
+
+describe('MIME_TYPES', () => {
+  it('maps every export format to its MIME string', () => {
+    expect(MIME_TYPES.pdf).toBe('application/pdf')
+    expect(MIME_TYPES.pptx).toBe(
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+    )
+    expect(MIME_TYPES.excel).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    )
+    expect(MIME_TYPES.csv).toBe('text/csv')
+  })
+})
+
+describe('FILE_EXTENSIONS', () => {
+  it('maps every export format to its file extension', () => {
+    expect(FILE_EXTENSIONS.pdf).toBe('.pdf')
+    expect(FILE_EXTENSIONS.pptx).toBe('.pptx')
+    expect(FILE_EXTENSIONS.excel).toBe('.xlsx')
+    expect(FILE_EXTENSIONS.csv).toBe('.csv')
+  })
+})
+
+describe('export format lookup consistency', () => {
+  const formats: ExportFormat[] = ['pdf', 'pptx', 'excel', 'csv']
+
+  it('MIME_TYPES and FILE_EXTENSIONS cover every ExportFormat', () => {
+    for (const format of formats) {
+      expect(MIME_TYPES[format]).toBeTruthy()
+      expect(FILE_EXTENSIONS[format]).toBeTruthy()
+    }
+  })
+
+  it('MIME_TYPES and FILE_EXTENSIONS expose the same set of formats', () => {
+    expect(Object.keys(MIME_TYPES).sort()).toEqual(Object.keys(FILE_EXTENSIONS).sort())
+  })
+})

--- a/tests/unit/services/import/import-types.test.ts
+++ b/tests/unit/services/import/import-types.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest'
+import {
+  IMPORT_CONFIG_VERSION,
+  IMPORT_LIMITS,
+  DEFAULT_IMPORT_OPTIONS,
+  SUPPORTED_FILE_TYPES,
+  IMPORT_ERROR_MESSAGES,
+  getErrorMessage,
+  type ImportErrorCode,
+} from '@/services/import/types'
+
+const IMPORT_ERROR_CODES: ImportErrorCode[] = [
+  'FILE_TOO_LARGE',
+  'INVALID_FILE_TYPE',
+  'PARSE_ERROR',
+  'PARSE_WARNING',
+  'MISSING_HEADERS',
+  'INVALID_HEADER',
+  'VALIDATION_ERROR',
+  'REQUIRED_FIELD',
+  'INVALID_FORMAT',
+  'INVALID_VALUE',
+  'DUPLICATE',
+  'REFERENCE_NOT_FOUND',
+  'BUSINESS_RULE_VIOLATION',
+  'DATABASE_ERROR',
+  'UNKNOWN_ERROR',
+]
+
+describe('IMPORT_CONFIG_VERSION', () => {
+  it('is a semver string', () => {
+    expect(IMPORT_CONFIG_VERSION).toBe('1.0.0')
+    expect(IMPORT_CONFIG_VERSION).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+})
+
+describe('IMPORT_LIMITS', () => {
+  it('caps CSV and Excel files at 10 MiB', () => {
+    const tenMiB = 10 * 1024 * 1024
+    expect(IMPORT_LIMITS.MAX_FILE_SIZE_CSV).toBe(tenMiB)
+    expect(IMPORT_LIMITS.MAX_FILE_SIZE_EXCEL).toBe(tenMiB)
+  })
+
+  it('defines operational thresholds', () => {
+    expect(IMPORT_LIMITS.MAX_ROWS).toBe(10000)
+    expect(IMPORT_LIMITS.BATCH_SIZE).toBe(500)
+    expect(IMPORT_LIMITS.TIMEOUT_MS).toBe(30000)
+    expect(IMPORT_LIMITS.PREVIEW_ROWS).toBe(10)
+    expect(IMPORT_LIMITS.MAX_ERRORS_DISPLAY).toBe(100)
+  })
+
+  it('keeps every limit strictly positive', () => {
+    for (const value of Object.values(IMPORT_LIMITS)) {
+      expect(value).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('DEFAULT_IMPORT_OPTIONS', () => {
+  it('skips duplicates and does not overwrite by default', () => {
+    expect(DEFAULT_IMPORT_OPTIONS.skipDuplicates).toBe(true)
+    expect(DEFAULT_IMPORT_OPTIONS.updateExisting).toBe(false)
+  })
+
+  it('defaults to Japanese and non-dry-run', () => {
+    expect(DEFAULT_IMPORT_OPTIONS.language).toBe('ja')
+    expect(DEFAULT_IMPORT_OPTIONS.dryRun).toBe(false)
+  })
+
+  it('populates every ImportOptions field', () => {
+    expect(Object.keys(DEFAULT_IMPORT_OPTIONS).sort()).toEqual(
+      ['dryRun', 'language', 'skipDuplicates', 'updateExisting'].sort()
+    )
+  })
+})
+
+describe('SUPPORTED_FILE_TYPES', () => {
+  it('accepts CSV by MIME type and extension', () => {
+    expect(SUPPORTED_FILE_TYPES.csv).toContain('text/csv')
+    expect(SUPPORTED_FILE_TYPES.csv).toContain('.csv')
+  })
+
+  it('accepts Excel by extension and MIME type', () => {
+    expect(SUPPORTED_FILE_TYPES.excel).toContain('.xlsx')
+    expect(SUPPORTED_FILE_TYPES.excel).toContain(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    )
+  })
+
+  it('does not cross-contaminate csv and excel types', () => {
+    expect(SUPPORTED_FILE_TYPES.csv).not.toContain('.xlsx')
+    expect(SUPPORTED_FILE_TYPES.excel).not.toContain('.csv')
+  })
+})
+
+describe('IMPORT_ERROR_MESSAGES', () => {
+  it('provides Japanese and English text for every error code', () => {
+    for (const code of IMPORT_ERROR_CODES) {
+      const messages = IMPORT_ERROR_MESSAGES[code]
+      expect(typeof messages.ja).toBe('string')
+      expect(messages.ja.length).toBeGreaterThan(0)
+      expect(typeof messages.en).toBe('string')
+      expect(messages.en.length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('getErrorMessage', () => {
+  it('returns the Japanese message for a known code', () => {
+    expect(getErrorMessage('FILE_TOO_LARGE', 'ja')).toBe('ファイルサイズが上限を超えています')
+  })
+
+  it('returns the English message for a known code', () => {
+    expect(getErrorMessage('DUPLICATE', 'en')).toBe('Duplicate data exists')
+  })
+
+  it('falls back to the UNKNOWN_ERROR message for an unrecognised code', () => {
+    expect(getErrorMessage('NOPE' as ImportErrorCode, 'ja')).toBe(
+      IMPORT_ERROR_MESSAGES.UNKNOWN_ERROR.ja
+    )
+    expect(getErrorMessage('NOPE' as ImportErrorCode, 'en')).toBe(
+      IMPORT_ERROR_MESSAGES.UNKNOWN_ERROR.en
+    )
+  })
+})

--- a/tests/unit/services/reports/ir-event-service-extended.test.ts
+++ b/tests/unit/services/reports/ir-event-service-extended.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { prisma } from '@/lib/db'
+import { getUpcomingIREvents } from '@/services/reports/ir-event-service'
+
+type MockFn = ReturnType<typeof vi.fn>
+
+type MockDb = {
+  $transaction: MockFn
+  iREvent: {
+    findMany: MockFn
+  }
+}
+
+const db = prisma as unknown as MockDb
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: vi.fn(),
+    iREvent: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+const mockEventList = [
+  {
+    id: 'ev-1',
+    companyId: 'company-1',
+    eventType: 'earnings',
+    title: '第1四半期決算説明会',
+    scheduledDate: new Date('2099-04-15'),
+    status: 'scheduled',
+  },
+  {
+    id: 'ev-2',
+    companyId: 'company-1',
+    eventType: 'meeting',
+    title: '株主総会',
+    scheduledDate: new Date('2099-06-20'),
+    status: 'scheduled',
+  },
+]
+
+describe('ir-event-service / getUpcomingIREvents (real export)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+      fn({ iREvent: db.iREvent })
+    )
+  })
+
+  it('fails with VALIDATION_ERROR when companyId is missing', async () => {
+    const result = await getUpcomingIREvents('')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('VALIDATION_ERROR')
+    }
+  })
+
+  it('returns upcoming scheduled events and limits to 10', async () => {
+    db.iREvent.findMany.mockResolvedValue(mockEventList)
+
+    const result = await getUpcomingIREvents('company-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual(mockEventList)
+    }
+
+    const callArg = db.iREvent.findMany.mock.calls[0][0] as {
+      where: Record<string, unknown>
+      take: number
+    }
+    expect(callArg.where).toMatchObject({
+      companyId: 'company-1',
+      status: 'scheduled',
+    })
+    expect((callArg.where.scheduledDate as { gte: unknown }).gte).toBeInstanceOf(Date)
+    expect(callArg.take).toBe(10)
+  })
+
+  it('returns an empty list when no upcoming events exist', async () => {
+    db.iREvent.findMany.mockResolvedValue([])
+
+    const result = await getUpcomingIREvents('company-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual([])
+    }
+  })
+
+  it('fails with DATABASE_ERROR when the transaction rejects', async () => {
+    db.iREvent.findMany.mockRejectedValue(new Error('boom'))
+
+    const result = await getUpcomingIREvents('company-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('DATABASE_ERROR')
+    }
+  })
+})

--- a/tests/unit/services/reports/ir-faq-service-extended.test.ts
+++ b/tests/unit/services/reports/ir-faq-service-extended.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { prisma } from '@/lib/db'
+import { getActiveFAQs } from '@/services/reports/ir-faq-service'
+
+type MockFn = ReturnType<typeof vi.fn>
+
+type MockDb = {
+  $transaction: MockFn
+  fAQ: {
+    findMany: MockFn
+  }
+}
+
+const db = prisma as unknown as MockDb
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: vi.fn(),
+    fAQ: {
+      findMany: vi.fn(),
+    },
+  },
+}))
+
+const mockFaqList = [
+  {
+    id: 'faq-1',
+    companyId: 'company-1',
+    question: '配当はいつですか？',
+    category: 'dividend',
+    sortOrder: 0,
+    isActive: true,
+  },
+  {
+    id: 'faq-2',
+    companyId: 'company-1',
+    question: '決算発表はいつですか？',
+    category: 'schedule',
+    sortOrder: 1,
+    isActive: true,
+  },
+]
+
+describe('ir-faq-service / getActiveFAQs (real export)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) => fn({ fAQ: db.fAQ }))
+  })
+
+  it('fails with VALIDATION_ERROR when companyId is missing', async () => {
+    const result = await getActiveFAQs('')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('VALIDATION_ERROR')
+    }
+  })
+
+  it('returns active FAQs ordered by sortOrder ascending', async () => {
+    db.fAQ.findMany.mockResolvedValue(mockFaqList)
+
+    const result = await getActiveFAQs('company-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual(mockFaqList)
+    }
+
+    const callArg = db.fAQ.findMany.mock.calls[0][0] as {
+      where: Record<string, unknown>
+      orderBy: Array<Record<string, unknown>>
+    }
+    expect(callArg.where).toMatchObject({ companyId: 'company-1', isActive: true })
+    expect(callArg.orderBy).toEqual([{ sortOrder: 'asc' }])
+  })
+
+  it('returns an empty list when no active FAQs exist', async () => {
+    db.fAQ.findMany.mockResolvedValue([])
+
+    const result = await getActiveFAQs('company-1')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).toEqual([])
+    }
+  })
+
+  it('fails with DATABASE_ERROR when the transaction rejects', async () => {
+    db.fAQ.findMany.mockRejectedValue(new Error('boom'))
+
+    const result = await getActiveFAQs('company-1')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('DATABASE_ERROR')
+    }
+  })
+})

--- a/tests/unit/services/reports/ir-shareholder-service-extended.test.ts
+++ b/tests/unit/services/reports/ir-shareholder-service-extended.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { prisma } from '@/lib/db'
+import {
+  getShareholderCompositions,
+  upsertShareholderComposition,
+  deleteShareholderComposition,
+  getLatestShareholderComposition,
+} from '@/services/reports/ir-shareholder-service'
+
+type MockFn = ReturnType<typeof vi.fn>
+
+type MockDb = {
+  $transaction: MockFn
+  shareholderComposition: {
+    findMany: MockFn
+    findFirst: MockFn
+    findUnique: MockFn
+    create: MockFn
+    update: MockFn
+    delete: MockFn
+  }
+}
+
+const db = prisma as unknown as MockDb
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    $transaction: vi.fn(),
+    shareholderComposition: {
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+    },
+  },
+}))
+
+const asOfDate = new Date('2024-03-31')
+
+const mockComposition = {
+  id: 'sc-1',
+  companyId: 'company-1',
+  asOfDate,
+  shareholderType: 'FINANCIAL_INSTITUTION',
+  shareholderName: 'テスト銀行',
+  sharesHeld: 1000,
+  percentage: 30,
+}
+
+const upsertInput = {
+  companyId: 'company-1',
+  asOfDate,
+  shareholderType: 'FINANCIAL_INSTITUTION',
+  shareholderName: 'テスト銀行',
+  sharesHeld: 1000,
+  percentage: 30,
+}
+
+describe('ir-shareholder-service (real exports)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    db.$transaction.mockImplementation(async (fn: (tx: unknown) => unknown) =>
+      fn({ shareholderComposition: db.shareholderComposition })
+    )
+  })
+
+  describe('getShareholderCompositions', () => {
+    it('fails with VALIDATION_ERROR when companyId is missing', async () => {
+      const result = await getShareholderCompositions('')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('returns compositions ordered as stored by the database', async () => {
+      db.shareholderComposition.findMany.mockResolvedValue([mockComposition])
+
+      const result = await getShareholderCompositions('company-1')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual([mockComposition])
+      }
+      expect(db.shareholderComposition.findMany).toHaveBeenCalledTimes(1)
+      const callArg = db.shareholderComposition.findMany.mock.calls[0][0] as {
+        where: Record<string, unknown>
+      }
+      expect(callArg.where).toMatchObject({ companyId: 'company-1' })
+    })
+
+    it('passes asOfDate and shareholderType filters into the where clause', async () => {
+      db.shareholderComposition.findMany.mockResolvedValue([])
+
+      await getShareholderCompositions('company-1', {
+        asOfDate,
+        shareholderType: 'INDIVIDUAL',
+      })
+
+      const callArg = db.shareholderComposition.findMany.mock.calls[0][0] as {
+        where: Record<string, unknown>
+      }
+      expect(callArg.where).toMatchObject({
+        companyId: 'company-1',
+        asOfDate,
+        shareholderType: 'INDIVIDUAL',
+      })
+    })
+
+    it('fails with DATABASE_ERROR when the transaction rejects', async () => {
+      db.shareholderComposition.findMany.mockRejectedValue(new Error('boom'))
+
+      const result = await getShareholderCompositions('company-1')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('DATABASE_ERROR')
+      }
+    })
+  })
+
+  describe('upsertShareholderComposition', () => {
+    it('creates a new composition when none exists', async () => {
+      db.shareholderComposition.findFirst.mockResolvedValue(null)
+      db.shareholderComposition.create.mockResolvedValue(mockComposition)
+
+      const result = await upsertShareholderComposition(upsertInput)
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual(mockComposition)
+      }
+      expect(db.shareholderComposition.create).toHaveBeenCalledTimes(1)
+      expect(db.shareholderComposition.update).not.toHaveBeenCalled()
+    })
+
+    it('updates the existing composition when a match is found', async () => {
+      db.shareholderComposition.findFirst.mockResolvedValue(mockComposition)
+      db.shareholderComposition.update.mockResolvedValue({
+        ...mockComposition,
+        percentage: 35,
+      })
+
+      const result = await upsertShareholderComposition(upsertInput)
+
+      expect(result.success).toBe(true)
+      expect(db.shareholderComposition.update).toHaveBeenCalledTimes(1)
+      expect(db.shareholderComposition.create).not.toHaveBeenCalled()
+    })
+
+    it('fails with VALIDATION_ERROR when companyId is missing', async () => {
+      const result = await upsertShareholderComposition({ ...upsertInput, companyId: '' })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('fails with VALIDATION_ERROR when asOfDate is not a Date', async () => {
+      const result = await upsertShareholderComposition({
+        ...upsertInput,
+        asOfDate: '2024-03-31' as unknown as Date,
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('fails with VALIDATION_ERROR when shareholderType is missing', async () => {
+      const result = await upsertShareholderComposition({
+        ...upsertInput,
+        shareholderType: '',
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('fails with VALIDATION_ERROR when sharesHeld is negative', async () => {
+      const result = await upsertShareholderComposition({
+        ...upsertInput,
+        sharesHeld: -5,
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('fails with VALIDATION_ERROR when percentage is out of range', async () => {
+      const result = await upsertShareholderComposition({
+        ...upsertInput,
+        percentage: 150,
+      })
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('fails with DATABASE_ERROR when the transaction rejects', async () => {
+      db.shareholderComposition.findFirst.mockRejectedValue(new Error('boom'))
+
+      const result = await upsertShareholderComposition(upsertInput)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('DATABASE_ERROR')
+      }
+    })
+  })
+
+  describe('deleteShareholderComposition', () => {
+    it('fails with VALIDATION_ERROR when id is missing', async () => {
+      const result = await deleteShareholderComposition('')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('deletes the composition and returns an empty list on success', async () => {
+      db.shareholderComposition.findUnique.mockResolvedValue(mockComposition)
+      db.shareholderComposition.delete.mockResolvedValue(mockComposition)
+
+      const result = await deleteShareholderComposition('sc-1')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual([])
+      }
+      expect(db.shareholderComposition.delete).toHaveBeenCalledTimes(1)
+    })
+
+    it('fails with NOT_FOUND when the composition does not exist', async () => {
+      db.shareholderComposition.findUnique.mockResolvedValue(null)
+
+      const result = await deleteShareholderComposition('missing')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('NOT_FOUND')
+        expect(result.error.message).toContain('missing')
+      }
+      expect(db.shareholderComposition.delete).not.toHaveBeenCalled()
+    })
+
+    it('fails with DATABASE_ERROR when the transaction rejects', async () => {
+      db.shareholderComposition.findUnique.mockRejectedValue(new Error('boom'))
+
+      const result = await deleteShareholderComposition('sc-1')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('DATABASE_ERROR')
+      }
+    })
+  })
+
+  describe('getLatestShareholderComposition', () => {
+    it('fails with VALIDATION_ERROR when companyId is missing', async () => {
+      const result = await getLatestShareholderComposition('')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('VALIDATION_ERROR')
+      }
+    })
+
+    it('returns the compositions for the latest asOfDate', async () => {
+      db.shareholderComposition.findFirst.mockResolvedValue({ asOfDate })
+      db.shareholderComposition.findMany.mockResolvedValue([mockComposition])
+
+      const result = await getLatestShareholderComposition('company-1')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual([mockComposition])
+      }
+    })
+
+    it('returns an empty list when no compositions exist', async () => {
+      db.shareholderComposition.findFirst.mockResolvedValue(null)
+
+      const result = await getLatestShareholderComposition('company-1')
+
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data).toEqual([])
+      }
+      expect(db.shareholderComposition.findMany).not.toHaveBeenCalled()
+    })
+
+    it('fails with DATABASE_ERROR when the transaction rejects', async () => {
+      db.shareholderComposition.findFirst.mockRejectedValue(new Error('boom'))
+
+      const result = await getLatestShareholderComposition('company-1')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('DATABASE_ERROR')
+      }
+    })
+  })
+})

--- a/tests/unit/services/reports/ir/ir-report-service.test.ts
+++ b/tests/unit/services/reports/ir/ir-report-service.test.ts
@@ -1,0 +1,538 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  getReport,
+  saveReport,
+  createReport,
+  deleteReport,
+  listReports,
+  updateReportStatus,
+  updateSection,
+  addSection,
+  removeSection,
+  updateFinancialHighlights,
+  updateShareholderComposition,
+  updateEvents,
+  updateFAQs,
+  generateSectionContent,
+} from '@/services/reports/ir/ir-report-service'
+import type {
+  IRReport,
+  IRReportSection,
+  FinancialHighlight,
+  ShareholderData,
+  IREvent,
+  FAQItem,
+} from '@/types/reports/ir-report'
+
+const STORAGE_KEY_PREFIX = 'ir_report_'
+
+function storageKey(reportId: string): string {
+  return `${STORAGE_KEY_PREFIX}${reportId}`
+}
+
+function createBaseReport(overrides: Partial<IRReport> = {}): IRReport {
+  return {
+    id: 'report-1',
+    companyId: 'company-1',
+    title: { ja: '決算報告', en: 'Financial Report' },
+    fiscalYear: '2024',
+    status: 'draft',
+    language: 'ja',
+    sections: [],
+    financialHighlights: [],
+    shareholderComposition: [],
+    events: [],
+    faqs: [],
+    metadata: {
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      createdBy: 'user-1',
+      lastModifiedBy: 'user-1',
+      version: 1,
+    },
+    ...overrides,
+  }
+}
+
+function createSection(overrides: Partial<IRReportSection> = {}): IRReportSection {
+  return {
+    id: 'sec-1',
+    type: 'company_overview',
+    title: { ja: '会社概要', en: 'Company Overview' },
+    content: { ja: '元の内容', en: 'original content' },
+    order: 0,
+    ...overrides,
+  }
+}
+
+function seedReport(report: IRReport): void {
+  localStorage.setItem(storageKey(report.id), JSON.stringify(report))
+}
+
+describe('ir/ir-report-service (localStorage)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  describe('getReport', () => {
+    it('returns null when the report is not stored', async () => {
+      expect(await getReport('missing')).toBeNull()
+    })
+
+    it('returns the parsed report when it exists', async () => {
+      const report = createBaseReport()
+      seedReport(report)
+
+      const result = await getReport(report.id)
+
+      expect(result).toEqual(report)
+    })
+
+    it('returns null when the stored payload is corrupt JSON', async () => {
+      localStorage.setItem(storageKey('report-1'), '{not valid json')
+
+      expect(await getReport('report-1')).toBeNull()
+    })
+  })
+
+  describe('saveReport', () => {
+    it('persists the report so getReport can read it back', async () => {
+      await saveReport(createBaseReport())
+
+      expect(await getReport('report-1')).not.toBeNull()
+    })
+
+    it('bumps the version and refreshes updatedAt on save', async () => {
+      await saveReport(
+        createBaseReport({ metadata: { ...createBaseReport().metadata, version: 5 } })
+      )
+
+      const stored = await getReport('report-1')
+      expect(stored?.metadata.version).toBe(6)
+      expect(stored?.metadata.updatedAt).not.toBe('2024-01-01T00:00:00.000Z')
+    })
+  })
+
+  describe('createReport', () => {
+    it('returns a draft report with default Japanese language and empty collections', async () => {
+      const report = await createReport({
+        companyId: 'company-1',
+        title: { ja: '決算報告', en: 'Financial Report' },
+        fiscalYear: '2024',
+        createdBy: 'user-1',
+      })
+
+      expect(report.status).toBe('draft')
+      expect(report.language).toBe('ja')
+      expect(report.sections).toEqual([])
+      expect(report.financialHighlights).toEqual([])
+      expect(report.shareholderComposition).toEqual([])
+      expect(report.events).toEqual([])
+      expect(report.faqs).toEqual([])
+      expect(report.metadata.version).toBe(1)
+      expect(report.metadata.createdBy).toBe('user-1')
+    })
+
+    it('respects an explicit language override', async () => {
+      const report = await createReport({
+        companyId: 'company-1',
+        title: { ja: '決算報告', en: 'Financial Report' },
+        fiscalYear: '2024',
+        language: 'en',
+        createdBy: 'user-1',
+      })
+
+      expect(report.language).toBe('en')
+    })
+
+    it('persists the created report', async () => {
+      const report = await createReport({
+        companyId: 'company-1',
+        title: { ja: '決算報告', en: 'Financial Report' },
+        fiscalYear: '2024',
+        createdBy: 'user-1',
+      })
+
+      expect(await getReport(report.id)).not.toBeNull()
+    })
+  })
+
+  describe('deleteReport', () => {
+    it('removes the report from storage', async () => {
+      seedReport(createBaseReport())
+      expect(await getReport('report-1')).not.toBeNull()
+
+      await deleteReport('report-1')
+
+      expect(await getReport('report-1')).toBeNull()
+    })
+
+    it('does not throw when deleting a missing report', async () => {
+      await expect(deleteReport('missing')).resolves.toBeUndefined()
+    })
+  })
+
+  describe('listReports', () => {
+    function seedList(): IRReport[] {
+      const older = createBaseReport({
+        id: 'r-old',
+        title: { ja: '前年報告', en: 'Previous Report' },
+        fiscalYear: '2023',
+        status: 'archived',
+        language: 'ja',
+        metadata: {
+          createdAt: '2023-01-01T00:00:00.000Z',
+          updatedAt: '2023-06-01T00:00:00.000Z',
+          createdBy: 'u',
+          lastModifiedBy: 'u',
+          version: 1,
+        },
+      })
+      const newer = createBaseReport({
+        id: 'r-new',
+        title: { ja: '今年報告', en: 'Latest Report' },
+        fiscalYear: '2024',
+        status: 'published',
+        language: 'en',
+        metadata: {
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-06-01T00:00:00.000Z',
+          createdBy: 'u',
+          lastModifiedBy: 'u',
+          version: 1,
+        },
+      })
+      const mid = createBaseReport({
+        id: 'r-mid',
+        title: { ja: '中間報告', en: 'Mid Report' },
+        fiscalYear: '2024',
+        status: 'draft',
+        language: 'ja',
+        metadata: {
+          createdAt: '2024-02-01T00:00:00.000Z',
+          updatedAt: '2024-03-01T00:00:00.000Z',
+          createdBy: 'u',
+          lastModifiedBy: 'u',
+          version: 1,
+        },
+      })
+      seedReport(older)
+      seedReport(newer)
+      seedReport(mid)
+      return [older, mid, newer]
+    }
+
+    it('returns an empty result when nothing is stored', async () => {
+      const result = await listReports()
+
+      expect(result.reports).toEqual([])
+      expect(result.total).toBe(0)
+      expect(result.page).toBe(1)
+      expect(result.pageSize).toBe(20)
+    })
+
+    it('returns all reports sorted by updatedAt descending', async () => {
+      seedList()
+      const sorted = await listReports()
+
+      expect(sorted.reports.map((r) => r.id)).toEqual(['r-new', 'r-mid', 'r-old'])
+      expect(sorted.total).toBe(3)
+    })
+
+    it('filters by status', async () => {
+      seedList()
+
+      const result = await listReports({ status: 'published' })
+
+      expect(result.reports).toHaveLength(1)
+      expect(result.reports[0].id).toBe('r-new')
+    })
+
+    it('filters by fiscalYear', async () => {
+      seedList()
+
+      const result = await listReports({ fiscalYear: '2024' })
+
+      expect(result.reports.map((r) => r.id).sort()).toEqual(['r-mid', 'r-new'])
+    })
+
+    it('filters by language', async () => {
+      seedList()
+
+      const result = await listReports({ language: 'en' })
+
+      expect(result.reports).toHaveLength(1)
+      expect(result.reports[0].id).toBe('r-new')
+    })
+
+    it('matches search against the Japanese title', async () => {
+      seedList()
+
+      const result = await listReports({ search: '中間' })
+
+      expect(result.reports).toHaveLength(1)
+      expect(result.reports[0].id).toBe('r-mid')
+    })
+
+    it('matches search against the English title (case-insensitive)', async () => {
+      seedList()
+
+      const result = await listReports({ search: 'latest' })
+
+      expect(result.reports).toHaveLength(1)
+      expect(result.reports[0].id).toBe('r-new')
+    })
+
+    it('skips entries that fail to parse', async () => {
+      seedList()
+      localStorage.setItem(storageKey('corrupt'), '{bad json')
+
+      const result = await listReports()
+
+      expect(result.total).toBe(3)
+    })
+  })
+
+  describe('updateReportStatus', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(updateReportStatus('missing', 'approved')).rejects.toThrow(
+        'Report not found: missing'
+      )
+    })
+
+    it('updates the status and persists the change', async () => {
+      seedReport(createBaseReport())
+
+      await updateReportStatus('report-1', 'approved')
+
+      const stored = await getReport('report-1')
+      expect(stored?.status).toBe('approved')
+    })
+
+    it('sets publishedAt when publishing', async () => {
+      seedReport(createBaseReport())
+
+      await updateReportStatus('report-1', 'published')
+
+      const stored = await getReport('report-1')
+      expect(stored?.status).toBe('published')
+      expect(stored?.metadata.publishedAt).toBeTruthy()
+    })
+  })
+
+  describe('updateSection', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(
+        updateSection('missing', 'sec-1', { content: { ja: 'x', en: 'x' } })
+      ).rejects.toThrow('Report not found: missing')
+    })
+
+    it('throws when the section does not exist', async () => {
+      seedReport(createBaseReport())
+
+      await expect(
+        updateSection('report-1', 'nope', { content: { ja: 'x', en: 'x' } })
+      ).rejects.toThrow('Section not found: nope')
+    })
+
+    it('merges updates into the existing section', async () => {
+      seedReport(createBaseReport({ sections: [createSection()] }))
+
+      await updateSection('report-1', 'sec-1', {
+        content: { ja: '新しい内容', en: 'new content' },
+      })
+
+      const stored = await getReport('report-1')
+      expect(stored?.sections[0].content).toEqual({ ja: '新しい内容', en: 'new content' })
+      expect(stored?.sections[0].title).toEqual({ ja: '会社概要', en: 'Company Overview' })
+    })
+  })
+
+  describe('addSection', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(
+        addSection('missing', {
+          type: 'company_overview',
+          title: { ja: 't', en: 't' },
+          content: { ja: 'c', en: 'c' },
+        })
+      ).rejects.toThrow('Report not found: missing')
+    })
+
+    it('appends a section with a generated id and trailing order', async () => {
+      seedReport(createBaseReport({ sections: [createSection({ id: 'sec-1', order: 0 })] }))
+
+      const added = await addSection('report-1', {
+        type: 'business_overview',
+        title: { ja: '事業概要', en: 'Business Overview' },
+        content: { ja: '内容', en: 'content' },
+      })
+
+      expect(added.id).toBeTruthy()
+      expect(added.order).toBe(1)
+      expect(added.type).toBe('business_overview')
+
+      const stored = await getReport('report-1')
+      expect(stored?.sections).toHaveLength(2)
+      expect(stored?.sections[1].id).toBe(added.id)
+    })
+  })
+
+  describe('removeSection', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(removeSection('missing', 'sec-1')).rejects.toThrow('Report not found: missing')
+    })
+
+    it('removes the section and reindexes the remaining order', async () => {
+      seedReport(
+        createBaseReport({
+          sections: [
+            createSection({ id: 'sec-1', order: 0 }),
+            createSection({ id: 'sec-2', order: 1, type: 'business_overview' }),
+          ],
+        })
+      )
+
+      await removeSection('report-1', 'sec-1')
+
+      const stored = await getReport('report-1')
+      expect(stored?.sections).toHaveLength(1)
+      expect(stored?.sections[0].id).toBe('sec-2')
+      expect(stored?.sections[0].order).toBe(0)
+    })
+  })
+
+  describe('updateFinancialHighlights', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(updateFinancialHighlights('missing', [])).rejects.toThrow(
+        'Report not found: missing'
+      )
+    })
+
+    it('replaces the financial highlights and persists', async () => {
+      seedReport(createBaseReport())
+
+      const highlights: FinancialHighlight[] = [
+        {
+          fiscalYear: '2024',
+          revenue: 1000,
+          operatingProfit: 200,
+          ordinaryProfit: 250,
+          netIncome: 180,
+          eps: 10,
+          bps: 100,
+          roe: 0.1,
+          roa: 0.05,
+        },
+      ]
+
+      await updateFinancialHighlights('report-1', highlights)
+
+      const stored = await getReport('report-1')
+      expect(stored?.financialHighlights).toEqual(highlights)
+    })
+  })
+
+  describe('updateShareholderComposition', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(updateShareholderComposition('missing', [])).rejects.toThrow(
+        'Report not found: missing'
+      )
+    })
+
+    it('replaces the shareholder composition and persists', async () => {
+      seedReport(createBaseReport())
+
+      const composition: ShareholderData[] = [{ category: 'financial', percentage: 30 }]
+
+      await updateShareholderComposition('report-1', composition)
+
+      const stored = await getReport('report-1')
+      expect(stored?.shareholderComposition).toEqual(composition)
+    })
+  })
+
+  describe('updateEvents', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(updateEvents('missing', [])).rejects.toThrow('Report not found: missing')
+    })
+
+    it('replaces the events and persists', async () => {
+      seedReport(createBaseReport())
+
+      const events: IREvent[] = [
+        { id: 'ev-1', title: '決算説明会', date: '2024-06-01', type: 'earnings' },
+      ]
+
+      await updateEvents('report-1', events)
+
+      const stored = await getReport('report-1')
+      expect(stored?.events).toEqual(events)
+    })
+  })
+
+  describe('updateFAQs', () => {
+    it('throws when the report does not exist', async () => {
+      await expect(updateFAQs('missing', [])).rejects.toThrow('Report not found: missing')
+    })
+
+    it('replaces the FAQs and persists', async () => {
+      seedReport(createBaseReport())
+
+      const faqs: FAQItem[] = [
+        {
+          id: 'faq-1',
+          question: { ja: '質問', en: 'Question' },
+          answer: { ja: '回答', en: 'Answer' },
+          order: 0,
+        },
+      ]
+
+      await updateFAQs('report-1', faqs)
+
+      const stored = await getReport('report-1')
+      expect(stored?.faqs).toEqual(faqs)
+    })
+  })
+
+  describe('generateSectionContent', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('returns the known template for a recognised section type', async () => {
+      const promise = generateSectionContent({
+        sectionType: 'company_overview',
+        context: { companyId: 'company-1', fiscalYear: '2024' },
+        language: 'ja',
+      })
+
+      await vi.advanceTimersByTimeAsync(500)
+      const result = await promise
+
+      expect(result.success).toBe(true)
+      expect(result.content?.ja).toContain('会社概要')
+      expect(result.content?.en).toContain('Company Overview')
+      expect(result.tokensUsed).toBe(150)
+    })
+
+    it('falls back to the generic template for an unmapped section type', async () => {
+      const promise = generateSectionContent({
+        sectionType: 'faq',
+        context: { companyId: 'company-1', fiscalYear: '2024' },
+        language: 'en',
+      })
+
+      await vi.advanceTimersByTimeAsync(500)
+      const result = await promise
+
+      expect(result.success).toBe(true)
+      expect(result.content?.en).toContain('AI-generated content')
+      expect(result.content?.ja).toContain('セクション内容')
+    })
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> Risk class C — standard PR review.

## Auto-generated PR — task `cov-svc-06`

**Risk class:** `C`
**Title:** Unit-test coverage: report + reports + export + import

### Files declared in task
- src/services/report
- src/services/reports
- src/services/export
- src/services/import
- tests/unit/services

### Files actually changed (8)
- docs/auto-sessions/cov-svc-06/summary.md
- tests/unit/services/export/export-service.test.ts
- tests/unit/services/export/export-types.test.ts
- tests/unit/services/import/import-types.test.ts
- tests/unit/services/reports/ir-event-service-extended.test.ts
- tests/unit/services/reports/ir-faq-service-extended.test.ts
- tests/unit/services/reports/ir-shareholder-service-extended.test.ts
- tests/unit/services/reports/ir/ir-report-service.test.ts


### Subagents declared
_(none)_

### Commit
`auto(C): Unit-test coverage: report + reports + export + import`

### Required human review
- [ ] Compliance review
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._