### PR TITLE
[auto/C] auto(C): Standardize Result<T,E> in non-Class-A services (analytics/budget/

### DIFF
--- a/docs/auto-sessions/err-01/summary.md
+++ b/docs/auto-sessions/err-01/summary.md
@@ -1,0 +1,95 @@
+# ERR-01 — Standardize `Result<T,E>` in non-Class-A services
+
+**Scope:** `src/services/{analytics,budget,cashflow,currency}`
+**Date:** 2026-07-08
+**Outcome:** Only `currency` had functions that `throw` for expected failures. Converted both;
+the other three services already avoid throwing for expected failures (see “Scope analysis”).
+
+## What changed
+
+### 1. `src/services/currency/exchange-rate.ts` — `createExchangeRateService`
+Before: `throw new Error(\`${source} exchange rate service not implemented\`)` for
+`ECB | MURC | OPEN_EXCHANGE | MANUAL`.
+After: returns `Result<ExchangeRateService, AppError>` — `success(new BOJExchangeRateService())`
+for BOJ/default, `failure(createAppError(ERROR_CODES.BUSINESS_LOGIC_ERROR, …))` for the
+unimplemented sources. Message text preserved exactly.
+
+### 2. `src/services/currency/currency-converter.ts` — `DefaultCurrencyConverter.convert`
+Before: `throw new Error('Cannot convert from … with rate …')` when the requested currency
+pair does not match the supplied `ExchangeRate`.
+After: returns `Result<CurrencyConversion, AppError>` — `success(…)` on both conversion
+directions and the same-currency shortcut; `failure(createAppError(BUSINESS_LOGIC_ERROR, …,
+{details}))` on mismatch (details include `from`, `to`, `rateFrom`, `rateTo`).
+
+Call sites updated within the same service:
+- `convertWithLatestRate` now returns `Promise<Result<CurrencyConversion, AppError>>`. The
+  `getLatestRate` await is wrapped in try/catch so a rate-service rejection is surfaced as
+  `failure(createAppError(EXTERNAL_SERVICE_ERROR, …))` instead of propagating a throw.
+- `createCurrencyConverter(service?)` now returns `Result<CurrencyConverter, AppError>` and
+  propagates the inner `createExchangeRateService('BOJ')` result (the failure branch is
+  unreachable for `'BOJ'` but kept for type-safety without re-introducing a throw).
+
+### 3. `src/services/currency/types.ts` — `CurrencyConverter` interface
+`convert` → `Result<CurrencyConversion, AppError>`;
+`convertWithLatestRate` → `Promise<Result<CurrencyConversion, AppError>>`. Added
+`type AppError` to the existing `@/types/result` import.
+
+## Class-A safety check
+The changed symbols (`convert`, `convertWithLatestRate`, `createCurrencyConverter`,
+`createExchangeRateService`, `CurrencyConverter`, `DefaultCurrencyConverter`) are used **only**
+within `src/services/currency/**` and re-exported from `src/services/currency/index.ts`. The
+sole external importer is `src/jobs/exchange-rate-fetch-job.ts`, which only uses
+`BOJRateProvider.fetchRates` (already a `Result`). **No Class-A path imports any changed
+signature**, so changing these public signatures is within the task constraints. A full-repo
+`tsc --noEmit` reports zero currency-related errors, confirming no other consumer broke.
+
+## Tests
+Updated the three affected test files to unwrap `Result` (repo idiom:
+`expect(r.success).toBe(true/false)` + guarded `if (r.success)` / `if (!r.success)`),
+replacing the old `expect(() => …).toThrow()` assertions, and **added/extended error-branch
+coverage**:
+- `currency-converter.test.ts`: incompatible-rate pair now asserts `BUSINESS_LOGIC_ERROR`
+  failure with exact message; **new** test “should return failure when the rate service
+  rejects” covers the `convertWithLatestRate` catch branch (`EXTERNAL_SERVICE_ERROR`).
+- `exchange-rate.test.ts`: `createExchangeRateService('ECB')` asserts failure with code +
+  message.
+- `exchange-rate-extended.test.ts`: `it.each(['MURC','OPEN_EXCHANGE','MANUAL'])` asserts
+  failure (code + message); BOJ source asserts success + instance.
+
+`currency-converter.test.ts` grew 21 → 22 tests.
+
+## Scope analysis — services left untouched (no `throw` for expected failures)
+A repo-wide `throw` search across the four service trees found throws **only** in currency
+(see above). The others were left unchanged because they do not throw on expected failures:
+
+- **analytics** (`financial-kpi.ts`, `kpi.ts`): all division goes through `safeDivide`
+  (returns 0 on zero denominator); division-by-zero and missing-data are handled by guards /
+  sentinels, never throws.
+- **budget** (`budget-service.ts`, `budget-import.ts`, `actual-vs-budget.ts`,
+  `detailed-actual-vs-budget.ts`): no explicit throws. DB ops surface failures via Prisma
+  promise rejections (not throws in our code). `importBudgetFromCsv` already returns a
+  structured `BudgetImportResult { success, errors[] }` and `validateBudgetCsv` returns
+  `{ valid, errors }` — both are already Result-shaped, no throws.
+- **cashflow** (`calculator.ts`, `cash-position.ts`, `runway-calculator.ts`): no throws.
+  Edge cases use `console.warn` + empty/sentinel returns (`createEmptyRunwayResult`,
+  999-runway, etc.); `validateAndApplyAdjustments` clamps values instead of throwing.
+
+## Notes / judgment calls
+- “Keep behavior identical”: success-path computation is unchanged; only the failure
+  *signaling* changed (throw → `failure`). The one new failure mode surfaced by
+  `convertWithLatestRate` (rate-service rejection) previously propagated as a thrown/rejected
+  promise — now returned as a `Result`, which is the intended standardization.
+- Zod `safeParse`: not applied here. The converted failures are **business-logic mismatches**
+  (currency pair incompatible with the rate; unsupported provider source), not malformed input.
+  All inputs are already statically typed (`Currency`, `ExchangeRateSource`, `ExchangeRate`),
+  so adding `safeParse` would only introduce *new* failure modes and break “behavior
+  identical.” No new helpers were added.
+- No `any`/`@ts-ignore`/`.skip`/lint-disable/coverage-lowering. No new dependencies.
+
+## Verification
+- `corepack pnpm install --frozen-lockfile` ✔
+- `corepack pnpm db:generate` (Prisma client — required for typecheck) ✔
+- `corepack pnpm exec vitest run` on the currency test dir → **6 files / 64 tests passed** ✔
+- `corepack pnpm exec tsc --noEmit` → 0 currency-related errors ✔
+- `node scripts/autopm_verify.mjs --changed-only` → **exit 0**
+  (typecheck 0/0, eslint exit 0, vitest 43 passed) ✔

--- a/src/services/currency/currency-converter.ts
+++ b/src/services/currency/currency-converter.ts
@@ -8,19 +8,32 @@ import {
 } from './types'
 import { createExchangeRateService } from './exchange-rate'
 import { addMonths } from 'date-fns'
+import {
+  type AppError,
+  type Result,
+  createAppError,
+  ERROR_CODES,
+  failure,
+  success,
+} from '@/types/result'
 
 export class DefaultCurrencyConverter implements CurrencyConverter {
   constructor(private rateService: ExchangeRateService) {}
 
-  convert(amount: number, from: Currency, to: Currency, rate: ExchangeRate): CurrencyConversion {
+  convert(
+    amount: number,
+    from: Currency,
+    to: Currency,
+    rate: ExchangeRate
+  ): Result<CurrencyConversion, AppError> {
     if (from === to) {
-      return {
+      return success({
         originalAmount: amount,
         originalCurrency: from,
         convertedAmount: amount,
         convertedCurrency: to,
         exchangeRate: rate,
-      }
+      })
     }
 
     let convertedAmount: number
@@ -30,28 +43,39 @@ export class DefaultCurrencyConverter implements CurrencyConverter {
     } else if (from === rate.toCurrency && to === rate.fromCurrency) {
       convertedAmount = amount * rate.rate
     } else {
-      throw new Error(
-        `Cannot convert from ${from} to ${to} with rate ${rate.fromCurrency}/${rate.toCurrency}`
+      return failure(
+        createAppError(
+          ERROR_CODES.BUSINESS_LOGIC_ERROR,
+          `Cannot convert from ${from} to ${to} with rate ${rate.fromCurrency}/${rate.toCurrency}`,
+          {
+            details: {
+              from,
+              to,
+              rateFrom: rate.fromCurrency,
+              rateTo: rate.toCurrency,
+            },
+          }
+        )
       )
     }
 
-    return {
+    return success({
       originalAmount: amount,
       originalCurrency: from,
       convertedAmount: Math.round(convertedAmount * 100) / 100,
       convertedCurrency: to,
       exchangeRate: rate,
-    }
+    })
   }
 
   async convertWithLatestRate(
     amount: number,
     from: Currency,
     to: Currency
-  ): Promise<CurrencyConversion> {
+  ): Promise<Result<CurrencyConversion, AppError>> {
     if (from === to) {
       const now = new Date()
-      return {
+      return success({
         originalAmount: amount,
         originalCurrency: from,
         convertedAmount: amount,
@@ -69,17 +93,33 @@ export class DefaultCurrencyConverter implements CurrencyConverter {
           createdAt: now,
           updatedAt: now,
         },
-      }
+      })
     }
 
-    const rate = await this.rateService.getLatestRate(from, to)
-    return this.convert(amount, from, to, rate)
+    try {
+      const rate = await this.rateService.getLatestRate(from, to)
+      return this.convert(amount, from, to, rate)
+    } catch (error) {
+      const cause = error instanceof Error ? error : new Error(String(error))
+      return failure(createAppError(ERROR_CODES.EXTERNAL_SERVICE_ERROR, cause.message, { cause }))
+    }
   }
 }
 
-export function createCurrencyConverter(service?: ExchangeRateService): CurrencyConverter {
-  const rateService = service || createExchangeRateService('BOJ')
-  return new DefaultCurrencyConverter(rateService)
+export function createCurrencyConverter(
+  service?: ExchangeRateService
+): Result<CurrencyConverter, AppError> {
+  let rateService: ExchangeRateService
+  if (service) {
+    rateService = service
+  } else {
+    const result = createExchangeRateService('BOJ')
+    if (!result.success) {
+      return failure(result.error)
+    }
+    rateService = result.data
+  }
+  return success(new DefaultCurrencyConverter(rateService))
 }
 
 export function calculateRunway(

--- a/src/services/currency/exchange-rate.ts
+++ b/src/services/currency/exchange-rate.ts
@@ -6,6 +6,14 @@ import {
   CurrencyCode,
 } from './types'
 import { exchangeRateCache } from '@/lib/cache'
+import {
+  type AppError,
+  type Result,
+  createAppError,
+  ERROR_CODES,
+  failure,
+  success,
+} from '@/types/result'
 
 export class BOJExchangeRateService implements ExchangeRateService {
   private baseUrl = 'https://www.boj.or.jp/statistics'
@@ -134,16 +142,23 @@ export class BOJExchangeRateService implements ExchangeRateService {
   }
 }
 
-export function createExchangeRateService(source: ExchangeRateSource = 'BOJ'): ExchangeRateService {
+export function createExchangeRateService(
+  source: ExchangeRateSource = 'BOJ'
+): Result<ExchangeRateService, AppError> {
   switch (source) {
     case 'BOJ':
-      return new BOJExchangeRateService()
+      return success(new BOJExchangeRateService())
     case 'ECB':
     case 'MURC':
     case 'OPEN_EXCHANGE':
     case 'MANUAL':
-      throw new Error(`${source} exchange rate service not implemented`)
+      return failure(
+        createAppError(
+          ERROR_CODES.BUSINESS_LOGIC_ERROR,
+          `${source} exchange rate service not implemented`
+        )
+      )
     default:
-      return new BOJExchangeRateService()
+      return success(new BOJExchangeRateService())
   }
 }

--- a/src/services/currency/types.ts
+++ b/src/services/currency/types.ts
@@ -1,4 +1,4 @@
-import { Result } from '@/types/result'
+import { Result, type AppError } from '@/types/result'
 
 export type CurrencyCode =
   | 'USD'
@@ -151,8 +151,17 @@ export interface CurrencyConversion {
 }
 
 export interface CurrencyConverter {
-  convert(amount: number, from: Currency, to: Currency, rate: ExchangeRate): CurrencyConversion
-  convertWithLatestRate(amount: number, from: Currency, to: Currency): Promise<CurrencyConversion>
+  convert(
+    amount: number,
+    from: Currency,
+    to: Currency,
+    rate: ExchangeRate
+  ): Result<CurrencyConversion, AppError>
+  convertWithLatestRate(
+    amount: number,
+    from: Currency,
+    to: Currency
+  ): Promise<Result<CurrencyConversion, AppError>>
 }
 
 export interface DualCurrencyDisplayProps {

--- a/tests/unit/services/currency/currency-converter.test.ts
+++ b/tests/unit/services/currency/currency-converter.test.ts
@@ -42,19 +42,25 @@ describe('DefaultCurrencyConverter', () => {
     it('should return same amount for same currency', () => {
       const result = converter.convert(1000, 'JPY', 'JPY', mockRate)
 
-      expect(result.originalAmount).toBe(1000)
-      expect(result.convertedAmount).toBe(1000)
-      expect(result.originalCurrency).toBe('JPY')
-      expect(result.convertedCurrency).toBe('JPY')
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.originalAmount).toBe(1000)
+        expect(result.data.convertedAmount).toBe(1000)
+        expect(result.data.originalCurrency).toBe('JPY')
+        expect(result.data.convertedCurrency).toBe('JPY')
+      }
     })
 
     it('should convert JPY to USD correctly', () => {
       const result = converter.convert(14950, 'JPY', 'USD', mockRate)
 
-      expect(result.originalAmount).toBe(14950)
-      expect(result.originalCurrency).toBe('JPY')
-      expect(result.convertedCurrency).toBe('USD')
-      expect(result.convertedAmount).toBeCloseTo(100, 0)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.originalAmount).toBe(14950)
+        expect(result.data.originalCurrency).toBe('JPY')
+        expect(result.data.convertedCurrency).toBe('USD')
+        expect(result.data.convertedAmount).toBeCloseTo(100, 0)
+      }
     })
 
     it('should convert USD to JPY correctly', () => {
@@ -74,13 +80,16 @@ describe('DefaultCurrencyConverter', () => {
 
       const result = converter.convert(100, 'USD', 'JPY', usdToJpyRate)
 
-      expect(result.originalAmount).toBe(100)
-      expect(result.originalCurrency).toBe('USD')
-      expect(result.convertedCurrency).toBe('JPY')
-      expect(result.convertedAmount).toBe(14950)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.originalAmount).toBe(100)
+        expect(result.data.originalCurrency).toBe('USD')
+        expect(result.data.convertedCurrency).toBe('JPY')
+        expect(result.data.convertedAmount).toBe(14950)
+      }
     })
 
-    it('should throw error for incompatible currency pair', () => {
+    it('should return failure for incompatible currency pair', () => {
       const incompatibleRate: ExchangeRate = {
         id: 'rate-3',
         rateDate: new Date('2024-01-15'),
@@ -95,13 +104,22 @@ describe('DefaultCurrencyConverter', () => {
         updatedAt: new Date(),
       }
 
-      expect(() => converter.convert(100, 'JPY', 'USD', incompatibleRate)).toThrow()
+      const result = converter.convert(100, 'JPY', 'USD', incompatibleRate)
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('BUSINESS_LOGIC_ERROR')
+        expect(result.error.message).toBe('Cannot convert from JPY to USD with rate EUR/GBP')
+      }
     })
 
     it('should round converted amount to 2 decimal places', () => {
       const result = converter.convert(10000, 'JPY', 'USD', { ...mockRate, rate: 149.33 })
 
-      expect(result.convertedAmount).toBe(Math.round((10000 / 149.33) * 100) / 100)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.convertedAmount).toBe(Math.round((10000 / 149.33) * 100) / 100)
+      }
     })
   })
 
@@ -109,8 +127,11 @@ describe('DefaultCurrencyConverter', () => {
     it('should return same amount for same currency without calling rate service', async () => {
       const result = await converter.convertWithLatestRate(1000, 'JPY', 'JPY')
 
-      expect(result.originalAmount).toBe(1000)
-      expect(result.convertedAmount).toBe(1000)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.originalAmount).toBe(1000)
+        expect(result.data.convertedAmount).toBe(1000)
+      }
       expect(mockRateService.getLatestRate).not.toHaveBeenCalled()
     })
 
@@ -118,13 +139,31 @@ describe('DefaultCurrencyConverter', () => {
       const result = await converter.convertWithLatestRate(14950, 'JPY', 'USD')
 
       expect(mockRateService.getLatestRate).toHaveBeenCalledWith('JPY', 'USD')
-      expect(result.convertedAmount).toBeCloseTo(100, 0)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.convertedAmount).toBeCloseTo(100, 0)
+      }
     })
 
     it('should include exchange rate in result', async () => {
       const result = await converter.convertWithLatestRate(14950, 'JPY', 'USD')
 
-      expect(result.exchangeRate).toEqual(mockRate)
+      expect(result.success).toBe(true)
+      if (result.success) {
+        expect(result.data.exchangeRate).toEqual(mockRate)
+      }
+    })
+
+    it('should return failure when the rate service rejects', async () => {
+      vi.mocked(mockRateService.getLatestRate).mockRejectedValueOnce(new Error('rate unavailable'))
+
+      const result = await converter.convertWithLatestRate(14950, 'JPY', 'USD')
+
+      expect(result.success).toBe(false)
+      if (!result.success) {
+        expect(result.error.code).toBe('EXTERNAL_SERVICE_ERROR')
+        expect(result.error.message).toBe('rate unavailable')
+      }
     })
   })
 })
@@ -141,13 +180,19 @@ describe('createCurrencyConverter', () => {
 
     const converter = createCurrencyConverter(mockService)
 
-    expect(converter).toBeInstanceOf(DefaultCurrencyConverter)
+    expect(converter.success).toBe(true)
+    if (converter.success) {
+      expect(converter.data).toBeInstanceOf(DefaultCurrencyConverter)
+    }
   })
 
   it('should create converter with default BOJ service when not provided', () => {
     const converter = createCurrencyConverter()
 
-    expect(converter).toBeInstanceOf(DefaultCurrencyConverter)
+    expect(converter.success).toBe(true)
+    if (converter.success) {
+      expect(converter.data).toBeInstanceOf(DefaultCurrencyConverter)
+    }
   })
 })
 

--- a/tests/unit/services/currency/exchange-rate-extended.test.ts
+++ b/tests/unit/services/currency/exchange-rate-extended.test.ts
@@ -77,15 +77,22 @@ describe('BOJExchangeRateService (extended)', () => {
 
 describe('createExchangeRateService (extended)', () => {
   it.each(['MURC', 'OPEN_EXCHANGE', 'MANUAL'] as ExchangeRateSource[])(
-    'throws for unsupported source %s',
+    'returns failure for unsupported source %s',
     (source) => {
-      expect(() => createExchangeRateService(source)).toThrow(
-        `${source} exchange rate service not implemented`
-      )
+      const service = createExchangeRateService(source)
+      expect(service.success).toBe(false)
+      if (!service.success) {
+        expect(service.error.code).toBe('BUSINESS_LOGIC_ERROR')
+        expect(service.error.message).toBe(`${source} exchange rate service not implemented`)
+      }
     }
   )
 
   it('returns a BOJ service for the explicit BOJ source', () => {
-    expect(createExchangeRateService('BOJ')).toBeInstanceOf(BOJExchangeRateService)
+    const service = createExchangeRateService('BOJ')
+    expect(service.success).toBe(true)
+    if (service.success) {
+      expect(service.data).toBeInstanceOf(BOJExchangeRateService)
+    }
   })
 })

--- a/tests/unit/services/currency/exchange-rate.test.ts
+++ b/tests/unit/services/currency/exchange-rate.test.ts
@@ -129,17 +129,26 @@ describe('BOJExchangeRateService', () => {
 describe('createExchangeRateService', () => {
   it('should create BOJ service by default', () => {
     const service = createExchangeRateService()
-    expect(service).toBeInstanceOf(BOJExchangeRateService)
+    expect(service.success).toBe(true)
+    if (service.success) {
+      expect(service.data).toBeInstanceOf(BOJExchangeRateService)
+    }
   })
 
   it('should create BOJ service when specified', () => {
     const service = createExchangeRateService('BOJ')
-    expect(service).toBeInstanceOf(BOJExchangeRateService)
+    expect(service.success).toBe(true)
+    if (service.success) {
+      expect(service.data).toBeInstanceOf(BOJExchangeRateService)
+    }
   })
 
-  it('should throw error for ECB service (not implemented)', () => {
-    expect(() => createExchangeRateService('ECB')).toThrow(
-      'ECB exchange rate service not implemented'
-    )
+  it('should return failure for ECB service (not implemented)', () => {
+    const service = createExchangeRateService('ECB')
+    expect(service.success).toBe(false)
+    if (!service.success) {
+      expect(service.error.code).toBe('BUSINESS_LOGIC_ERROR')
+      expect(service.error.message).toBe('ECB exchange rate service not implemented')
+    }
   })
 })


### PR DESCRIPTION
> [!NOTE]
> Risk class C — standard PR review.

## Auto-generated PR — task `err-01`

**Risk class:** `C`
**Title:** Standardize Result<T,E> in non-Class-A services (analytics/budget/cashflow/currency)

### Files declared in task
- src/services/analytics
- src/services/budget
- src/services/cashflow
- src/services/currency

### Files actually changed (7)
- docs/auto-sessions/err-01/summary.md
- src/services/currency/currency-converter.ts
- src/services/currency/exchange-rate.ts
- src/services/currency/types.ts
- tests/unit/services/currency/currency-converter.test.ts
- tests/unit/services/currency/exchange-rate-extended.test.ts
- tests/unit/services/currency/exchange-rate.test.ts


### Subagents declared
_(none)_

### Commit
`auto(C): Standardize Result<T,E> in non-Class-A services (analytics/budget/cashflow/currency)`

### Required human review
- [ ] Compliance review
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._