### PR TITLE
[auto/B] auto(B): 予実 journal-level variance-attribution module (strengthen budget se

### DIFF
--- a/docs/auto-sessions/fin-impl-01/summary.md
+++ b/docs/auto-sessions/fin-impl-01/summary.md
@@ -1,0 +1,167 @@
+# FIN-IMPL-01 — Journal-Level Budget-Variance Attribution (予実要因分析)
+
+**Status:** Implementation complete. Verify gate green.
+**⚠️ FINANCIAL OUTPUT — human review required before merge.**
+
+---
+
+## ⚠️ PR Labels (REQUIRED — do NOT auto-merge)
+
+This is financial output. The PR for this branch **MUST** be labelled:
+
+- `human-review-required`
+- `do-not-auto-merge`
+
+Both labels exist in the repo. **Do NOT let this PR auto-merge.** The owner must verify every
+formula and assumption listed below (§"Formula list", §"Assumptions / PENDING HUMAN
+DETERMINATION") before merge. If the automation framework defaults to `auto-merge`, override
+it with `do-not-auto-merge`.
+
+---
+
+## What was implemented
+
+Implements the methodology in `docs/proposals/fin-design-01-variance-attribution.md` (Phase 1 +
+Phase 2 of its suggested phasing): account-level driver decomposition (Layer A) and journal-level
+attribution with M0 expected amounts + reconciliation gap (Layer B). Journals are read-only inputs;
+all computation is in the non-Class-A budget service. No Class-A path was modified.
+
+### Files
+
+| File | Change |
+|------|--------|
+| `src/services/budget/variance-attribution.ts` | **NEW** — pure attribution core. Types, Zod schemas, `attributeVariance()` (returns `Result<T,E>`), and helpers. No Prisma/I/O. |
+| `src/services/budget/variance-attribution-loader.ts` | **NEW** — account-key resolver, journal→account resolution, `prepareAttributionInput()` (pure), and `computeVarianceAttribution()` (async, reads Budget+Journal+AccountItem read-only, returns `Result`). |
+| `src/services/budget/detailed-actual-vs-budget.ts` | **STRENGTHENED** — added `favorable: boolean\|null` (§6.2 sign convention) to `StageLevelComparison` and `AccountLevelComparison`. Additive; no existing field/test changed. |
+| `tests/unit/services/budget/variance-attribution.test.ts` | **NEW** — 30 golden tests, hand-computed expected numbers + edge cases + reconciliation-identity property. |
+| `tests/unit/services/budget/variance-attribution-loader.test.ts` | **NEW** — resolver, journal resolution, `prepareAttributionInput`, and async `computeVarianceAttribution` (mocked DB). |
+| `tests/unit/services/budget/detailed-actual-vs-budget.test.ts` | **STRENGTHENED** — added favorable-classification assertions. |
+
+### Verification
+
+`node scripts/autopm_verify.mjs --changed-only` → **exit 0**
+(typecheck 0 errors, eslint 0 warnings, 68 tests pass across the 3 resolved test files;
+170 tests pass in the full budget suite).
+
+---
+
+## Architecture
+
+Pure core + thin DB loader, so the attribution math is fully testable with hand-computed numbers
+and never coupled to Prisma mocks:
+
+- `attributeVariance(input, options)` — pure. Validates input with Zod `safeParse`; returns
+  `Result<VarianceAttribution, AppError>`. Does the variance/driver/ranking/reconciliation math.
+- `prepareAttributionInput({actuals, budgets, journals, accountItems, ...})` — pure. Builds the
+  name→account resolver, resolves journals to P&L accounts (debit/credit side), unions actuals ∪
+  budgets into per-account inputs.
+- `computeVarianceAttribution({companyId, fiscalYear, month, actuals, options})` — async. Loads
+  Budget + Journal + AccountItem (read-only), delegates to the two pure functions, returns `Result`.
+
+### Reconciliation identity (enforced by construction, asserted in tests)
+
+```
+StaticVariance_a = (Σ deviation_j) + ReconciliationGap_a
+  deviation_j       = signedAmount_j − expected_j
+  expected_j        = Budget_a / |J_a|            (M0; Σ expected_j = Budget_a when |J_a|>0)
+  ReconciliationGap = Actual_a − Σ signedAmount_j
+```
+
+So `Σ driver amounts (incl. unreconciled) = variance` and `Σ pctOfVariance = 100` (signed). Both
+are asserted as golden/property tests.
+
+---
+
+## Formula list (for owner verification)
+
+Every formula below is cited to a standard definition or to the proposal section. Verify each.
+
+| # | Formula | Citation |
+|---|---------|----------|
+| 1 | `variance = actual − budget` | Static-budget (Level 1) variance — Horngren/Datar/Rajan, *Cost Accounting*; proposal §3 |
+| 2 | Favorable when variance increases operating income: revenue/profit over budget = F; expense under budget = F; `null` when variance = 0 | Standard sign convention; proposal §3, §6.2 |
+| 3 | `signedAmount = side==='credit' ? +amount : −amount` (revenue); `side==='debit' ? +amount : −amount` (expense) | Double-entry (credit↑revenue, debit↑expense); proposal §6.4 step 1 |
+| 4 | `expected = budget / |J_a|` (M0 uniform spread) | Proposal §6.4 step 2, model M0 |
+| 5 | `deviation = signedAmount − expected` | Proposal §6.4 step 3 |
+| 6 | `variance = Σ deviation_j + unreconciled`, `unreconciled = actual − Σ signedAmount_j` | Proposal §6.5 reconciliation identity |
+| 7 | `z = (x − μ) / σ` over the account's signed journal amounts (population stddev); `null` when `n<2` or `σ=0` | Proposal §6.4 step 3 (outlier flagging) |
+| 8 | `materialityThreshold = max(absoluteFloor, pctOfRevenue × totalRevenue)`; account material when `|variance| ≥ threshold` | Proposal §6.2 |
+| 9 | Driver precedence per journal: `new_unbudgeted` (budget=0) > `outlier` (`|z| ≥ threshold`) > `timing` (period-boundary date) > `run_rate` (residual) | Proposal §6.1, §6.4 |
+| 10 | `driverAmount = Σ deviation_j for j in driver`; `Σ driverAmounts + unreconciled = variance` | Proposal §6.4 step 5, §6.5 |
+| 11 | `contributionPct = deviation / variance × 100`; `pctOfVariance = amount / variance × 100` (both signed); `Σ pctOfVariance = 100` | Proposal §6.4 step 3 / §8 |
+| 12 | `achievementRate = actual / budget × 100`, `null` when `budget = 0` | Proposal §6.2 |
+| 13 | `variancePct = variance / budget × 100`, `null` when `budget = 0` | Proposal §6.2 |
+| 14 | `unreconciledPct = unreconciled / max(|actual|, |journalSum|) × 100`, `null` when denominator 0 | Proposal §6.5 / §8 |
+| 15 | `journalAttributionConfidence = 'low'` when `|unreconciled| / max(|actual|, |budget|, 1) > unreconciledTolerancePct`, else `'high'` | Proposal §6.5 |
+| 16 | Edge cases: immaterial → aggregated (not exploded to journals); `n=0 & actual≈0` → `absence`; `n=0 & actual material` → `unreconciled`; `budget=0 & actual≠0` → `new_unbudgeted` | Proposal §6.2, §6.3 |
+| 17 | `budgetCoveragePct = (actual-bearing accounts with budget>0) / (actual-bearing accounts) × 100` | Proposal §8 `dataQuality` |
+| 18 | Summary at operating-income level: `totalBudget = Σ revenue.budget − Σ (cost+sga).budget`; `totalActual` likewise; `totalVariance = totalActual − totalBudget` | Proposal §8 `summary` |
+
+### Default thresholds (all `PENDING HUMAN DETERMINATION` — proposal §6.2, §11.5)
+
+`topK=10`, `materialityAbsoluteFloor=10000`, `materialityPctOfRevenue=0.005` (0.5%),
+`outlierZThreshold=2.5`, `unreconciledTolerancePct=0.10` (10%), `expectedModel='M0'`.
+
+---
+
+## Assumptions / `PENDING HUMAN DETERMINATION`
+
+These are the judgemental choices. Each defaults to the most conservative option and is flagged
+`// PENDING HUMAN DETERMINATION` in the source. The owner must decide.
+
+1. **Full PVVM (price/volume/mix) is NOT computed.** `Journal` stores no quantity/unit-price and no
+   partner/segment/tag dimensions (proposal §4.3 — both sync paths discard them). The combined
+   volume×price effect that cannot be split is reported as the `run_rate` residual. Splitting it
+   needs §7.1 (dimension capture) + §7.2 (quantity) — Class-A schema changes, out of scope.
+2. **Account-key crosswalk is best-effort.** Journals store the account *name*; budgets store a
+   user *code*; `MonthlyBalance` stores a freee numeric *id* or user code (§4.3). The resolver
+   matches by name (actuals authoritative, then budget prefix, then `AccountItem`). Journals that
+   fail to resolve are counted as `unmatched` and never attributed. A canonical crosswalk (§7.3) is
+   Class-A, out of scope.
+3. **Category mapping on the freee path is broken and NOT fixed.** `getCategoryFromAccountItem`
+   (`data-sync.ts:187`) has a dead `revenue` branch and no `cost_of_sales` branch (§4.4). The fix is
+   Class-A (freee integration). Revenue/COGS variances are flagged `category_mapping_unverified_freee_path`.
+4. **Period window assumes calendar alignment.** `fiscalYear`/`month` are treated as calendar
+   year/month. Fiscal-year-start handling is out of scope (PENDING).
+5. **Timing driver is a period-boundary heuristic only.** Reversing-pair detection and
+   `Prepaid`/`Accrued` linkage are NOT implemented (PENDING). Only first/last-day-of-month journals
+   are tagged `timing`.
+6. **Absence vs unreconciled boundary (no journals).** When `|actual|` is below the materiality
+   floor → `absence`; otherwise the whole variance is `unreconciled` (actual with no journal backing).
+   PENDING.
+7. **Department-level variance is NOT feasible.** `Journal` has no `departmentId`/segment (§4.3).
+   `departmentId` filters budgets only; journals stay company-wide. Needs §7.6 (Class-A).
+8. **Driver precedence** (`new_unbudgeted > outlier > timing > run_rate`) is a proposal; PENDING.
+9. **Population (n) stddev** chosen over sample (n−1); PENDING.
+10. **All thresholds** (§"Default thresholds") are starting points; PENDING human tuning.
+11. **`expectedModel` M0 only.** M1 (temporal), M2 (prior-year), M3 (driver-based PVVM) are not
+    implemented and return `BUSINESS_LOGIC_ERROR` if requested.
+12. **No route integration.** The budget API route (`src/app/api/reports/budget/route.ts`) feeds
+    hardcoded sample P&L, and `mapBalancesToProfitLoss` silently falls back to sample data when
+    `MonthlyBalance` is empty (§4.2). Wiring the new service to the route is deferred pending the
+    Class-A data fixes (§7.3/§7.4) so attribution is never run on synthetic actuals. Callers must
+    pass `actualsSource: 'sample'|'mock'` when feeding synthetic P&L (fires `actuals_are_synthetic`).
+
+### Conservative defaults (non-judgemental safety)
+
+- Unsupported `expectedModel` → `failure` (no silent fallback).
+- Invalid input → `failure` (Zod `safeParse`).
+- DB error → `failure` (`DATABASE_ERROR`).
+- Immaterial variance → aggregated, not exploded to journals.
+- `unreconciled` is its own bucket, never absorbed into `run_rate`.
+- `dimensionCoverage` is always `{partner:false, segment:false, quantity:false}` (factual).
+
+---
+
+## Scope compliance
+
+- No Class-A path modified (schema, migrations, auth, crypto, security, audit, conversion,
+  valuation, tax, kpi, debt, deferred-accrual, journal-proposal, freee integration, the listed
+  api routes, python/r services). All were read-only reference at most.
+- Journals / `MonthlyBalance` / `Budget` / `AccountItem` are read-only inputs.
+- Additive/strengthening; reuses existing `getBudgetsByMonth`, `safeDivide`, `Result`/`AppError`,
+  `ProfitLoss` types. No new dependencies.
+- New helpers return `Result<T,E>`; inputs validated with Zod `safeParse`.
+- Golden tests: hand-computed expected numbers (summer-bonus outlier, reconciliation gap, new
+  unbudgeted, absence, unreconciled, immaterial, revenue sales-return, negative actual) plus a
+  reconciliation-identity property test. Real assertions only; no fake green.

--- a/src/services/budget/detailed-actual-vs-budget.ts
+++ b/src/services/budget/detailed-actual-vs-budget.ts
@@ -1,6 +1,7 @@
 import type { ProfitLoss } from '@/types'
 import { safeDivide } from '@/lib/utils'
 import { getBudgetsByMonth } from './budget-service'
+import { classifyFavorable } from './variance-attribution'
 
 export interface StageLevelComparison {
   stage: string
@@ -9,6 +10,14 @@ export interface StageLevelComparison {
   variance: number
   rate: number
   status: 'good' | 'warning' | 'bad'
+  /**
+   * Favorable/unfavorable classification by P&L direction (proposal §6.2). `true` when the
+   * variance increases operating income relative to budget (revenue/profit over budget is
+   * favorable; expense under budget is favorable), `false` when unfavorable, `null` when the
+   * variance is zero. Replaces the ambiguous over/under-by-sign labeling for consumers that
+   * need the standard sign convention.
+   */
+  favorable: boolean | null
 }
 
 export interface AccountLevelComparison {
@@ -20,6 +29,11 @@ export interface AccountLevelComparison {
   variance: number
   rate: number
   status: 'good' | 'warning' | 'bad'
+  /**
+   * Favorable/unfavorable classification by P&L direction (proposal §6.2). See
+   * {@link StageLevelComparison.favorable}.
+   */
+  favorable: boolean | null
 }
 
 export interface DetailedActualVsBudget {
@@ -83,6 +97,7 @@ export async function calculateDetailedActualVsBudget(
       variance: totalRevenueActual - totalRevenueBudget,
       rate: safeDivide(totalRevenueActual, totalRevenueBudget) * 100,
       status: getRevenueStatus(totalRevenueActual, totalRevenueBudget),
+      favorable: classifyFavorable(totalRevenueActual, totalRevenueBudget, 'revenue'),
     },
     {
       stage: '売上原価',
@@ -91,6 +106,7 @@ export async function calculateDetailedActualVsBudget(
       variance: totalCostActual - totalCostBudget,
       rate: safeDivide(totalCostActual, totalCostBudget) * 100,
       status: getExpenseStatus(totalCostActual, totalCostBudget),
+      favorable: classifyFavorable(totalCostActual, totalCostBudget, 'expense'),
     },
     {
       stage: '売上総利益',
@@ -99,6 +115,7 @@ export async function calculateDetailedActualVsBudget(
       variance: grossProfitActual - grossProfitBudget,
       rate: safeDivide(grossProfitActual, grossProfitBudget) * 100,
       status: getRevenueStatus(grossProfitActual, grossProfitBudget),
+      favorable: classifyFavorable(grossProfitActual, grossProfitBudget, 'revenue'),
     },
     {
       stage: '販売管理費',
@@ -107,6 +124,7 @@ export async function calculateDetailedActualVsBudget(
       variance: totalSgaActual - totalSgaBudget,
       rate: safeDivide(totalSgaActual, totalSgaBudget) * 100,
       status: getExpenseStatus(totalSgaActual, totalSgaBudget),
+      favorable: classifyFavorable(totalSgaActual, totalSgaBudget, 'expense'),
     },
     {
       stage: '営業利益',
@@ -115,6 +133,7 @@ export async function calculateDetailedActualVsBudget(
       variance: operatingIncomeActual - operatingIncomeBudget,
       rate: safeDivide(operatingIncomeActual, operatingIncomeBudget) * 100,
       status: getRevenueStatus(operatingIncomeActual, operatingIncomeBudget),
+      favorable: classifyFavorable(operatingIncomeActual, operatingIncomeBudget, 'revenue'),
     },
     {
       stage: '当期純利益',
@@ -123,6 +142,7 @@ export async function calculateDetailedActualVsBudget(
       variance: actualPL.netIncome - operatingIncomeBudget * 0.7,
       rate: safeDivide(actualPL.netIncome, operatingIncomeBudget * 0.7) * 100,
       status: getRevenueStatus(actualPL.netIncome, operatingIncomeBudget * 0.7),
+      favorable: classifyFavorable(actualPL.netIncome, operatingIncomeBudget * 0.7, 'revenue'),
     },
   ]
 
@@ -139,6 +159,7 @@ export async function calculateDetailedActualVsBudget(
       variance: item.amount - budget,
       rate: safeDivide(item.amount, budget) * 100,
       status: getRevenueStatus(item.amount, budget),
+      favorable: classifyFavorable(item.amount, budget, 'revenue'),
     })
   }
 
@@ -153,6 +174,7 @@ export async function calculateDetailedActualVsBudget(
       variance: item.amount - budget,
       rate: safeDivide(item.amount, budget) * 100,
       status: getExpenseStatus(item.amount, budget),
+      favorable: classifyFavorable(item.amount, budget, 'expense'),
     })
   }
 
@@ -167,6 +189,7 @@ export async function calculateDetailedActualVsBudget(
       variance: item.amount - budget,
       rate: safeDivide(item.amount, budget) * 100,
       status: getExpenseStatus(item.amount, budget),
+      favorable: classifyFavorable(item.amount, budget, 'expense'),
     })
   }
 

--- a/src/services/budget/variance-attribution-loader.ts
+++ b/src/services/budget/variance-attribution-loader.ts
@@ -1,0 +1,449 @@
+import { prisma } from '@/lib/db'
+import type { ProfitLoss } from '@/types'
+import {
+  failure,
+  tryCatch,
+  createAppError,
+  ERROR_CODES,
+  type Result,
+  type AppError,
+} from '@/types/result'
+import { getBudgetsByMonth } from './budget-service'
+import {
+  attributeVariance,
+  type ActualsSource,
+  type AccountAttributionInput,
+  type AttributionInput,
+  type AttributionOptions,
+  type JournalEntry,
+  type VarianceAttribution,
+} from './variance-attribution'
+
+/**
+ * FIN-IMPL-01 — DB loader + account-key crosswalk for variance attribution.
+ *
+ * The pure attribution math lives in `variance-attribution.ts`. This module:
+ *   1. Builds an account-key resolver from the union of actuals, budgets, and
+ *      `AccountItem` rows (proposal §4.3: there are three incompatible account keys —
+ *      journal stores the account *name*, budget stores a user *code*, MonthlyBalance
+ *      stores a freee numeric *id* or user code). The resolver maps a journal's account
+ *      name to the canonical accountCode + P&L category. It is best-effort; journals that
+ *      fail to resolve are counted as `unmatched` and never attributed (honest signal).
+ *   2. Resolves each journal to the P&L account(s) it touches (debit and/or credit side).
+ *   3. Loads Budget + Journal + AccountItem (READ-ONLY inputs) and calls the pure core.
+ *
+ * `Journal`/`Budget`/`AccountItem` are read-only here; no Class-A path is modified.
+ */
+
+export type PlCategory = 'revenue' | 'cost_of_sales' | 'sga_expense'
+
+export interface AccountResolution {
+  accountCode: string
+  accountName: string
+  category: PlCategory
+}
+
+/** Maps a journal account key (the stored account *name*) → canonical resolution. */
+export type AccountResolver = (accountKey: string) => AccountResolution | null
+
+/** Minimal Budget shape consumed by the loader (subset of the Prisma `Budget` row). */
+export interface BudgetRow {
+  accountCode: string
+  accountName: string
+  amount: number
+  departmentId?: string | null
+}
+
+/** Minimal Journal shape consumed by the loader (subset of the Prisma `Journal` row). */
+export interface JournalRow {
+  id: string
+  freeeJournalId: string
+  entryDate: Date
+  description: string
+  debitAccount: string
+  creditAccount: string
+  amount: number
+}
+
+/** Minimal AccountItem shape consumed by the loader (subset of the Prisma row). */
+export interface AccountItemRow {
+  name: string
+  shortcut?: string | null
+  shortcutNum?: string | null
+  freeeId: number
+  categoryType?: string | null
+}
+
+/**
+ * Infers a P&L category from an account code by prefix (4xx revenue, 5xx cost of sales,
+ * 6xx/7xx SGA). This duplicates the prefix method in `detailed-actual-vs-budget.ts:193`
+ * and intentionally DISAGREES with the freee id-range method in `data-sync.ts:187`
+ * (proposal §4.4). Used only as a fallback for accounts absent from the actuals P&L
+ * (budget-only or AccountItem-only rows), where no authoritative category exists.
+ *
+ * Returns `null` for non-P&L / below-the-line prefixes (assets 1xx, liabilities 2xx,
+ * equity 3xx, non-operating 8xx/9xx) so the resolver never attributes a balance-sheet
+ * account or a synthetic below-the-line section (proposal §6.3 not_applicable).
+ *
+ * `PENDING HUMAN DETERMINATION`: replace both methods with a single authoritative
+ * account→category map driven by `AccountItem.categoryType` (proposal §7.4, Class-A).
+ */
+export function inferCategoryFromCode(code: string): PlCategory | null {
+  if (code.startsWith('4')) return 'revenue'
+  if (code.startsWith('5')) return 'cost_of_sales'
+  if (code.startsWith('6') || code.startsWith('7')) return 'sga_expense'
+  return null
+}
+
+/**
+ * Infers a P&L category from an `AccountItem.categoryType` string, with prefix fallback.
+ * freee `category_type` values include `assets`, `liabilities`, `equity`, `income`,
+ * `expense`, `cogs`/`cost_of_sales`. Mapping is conservative: only `income`→revenue,
+ * `cogs`/`cost_of_sales`→cost_of_sales, and `expense`→sga_expense are inferred; balance-
+ * sheet types fall back to the code prefix (and return `null` for non-P&L codes) so they
+ * are never attributed.
+ *
+ * `PENDING HUMAN DETERMINATION` on the exact `category_type` vocabulary.
+ */
+function inferCategoryFromType(
+  categoryType: string | null | undefined,
+  fallbackCode: string
+): PlCategory | null {
+  const t = (categoryType ?? '').toLowerCase()
+  if (t === 'income' || t === 'revenue') return 'revenue'
+  if (t === 'cogs' || t === 'cost_of_sales') return 'cost_of_sales'
+  if (t === 'expense') return 'sga_expense'
+  return inferCategoryFromCode(fallbackCode)
+}
+
+/**
+ * Builds a name→resolution map from the union of actuals (authoritative category), budget
+ * rows, and AccountItem rows. Actuals win because their P&L array position is the only
+ * authoritative category source; budgets and AccountItems are fallbacks (prefix/type
+ * inferred). Lookup is by account *name* because `Journal.debitAccount`/`creditAccount`
+ * store the account name (proposal §4.3).
+ *
+ * @param actuals - Actual P&L (carries authoritative code + name + category).
+ * @param budgets - Budget rows (code + name).
+ * @param accountItems - AccountItem rows (name + shortcut/shortcutNum/freeeId + type).
+ * @returns A resolver function from account name to resolution (or `null`).
+ */
+export function buildAccountResolver(params: {
+  actuals: ProfitLoss
+  budgets: BudgetRow[]
+  accountItems?: AccountItemRow[]
+}): AccountResolver {
+  const byName = new Map<string, AccountResolution>()
+
+  for (const r of params.actuals.revenue) {
+    byName.set(r.name, { accountCode: r.code, accountName: r.name, category: 'revenue' })
+  }
+  for (const c of params.actuals.costOfSales) {
+    byName.set(c.name, { accountCode: c.code, accountName: c.name, category: 'cost_of_sales' })
+  }
+  for (const e of params.actuals.sgaExpenses) {
+    byName.set(e.name, { accountCode: e.code, accountName: e.name, category: 'sga_expense' })
+  }
+
+  for (const b of params.budgets) {
+    if (byName.has(b.accountName)) continue
+    const category = inferCategoryFromCode(b.accountCode)
+    if (category === null) continue // non-P&L / below-the-line budget: not attributable
+    byName.set(b.accountName, {
+      accountCode: b.accountCode,
+      accountName: b.accountName,
+      category,
+    })
+  }
+
+  for (const ai of params.accountItems ?? []) {
+    if (byName.has(ai.name)) continue
+    const code = ai.shortcutNum ?? ai.shortcut ?? String(ai.freeeId)
+    const category = inferCategoryFromType(ai.categoryType, code)
+    if (category === null) continue // balance-sheet account: not attributable
+    byName.set(ai.name, { accountCode: code, accountName: ai.name, category })
+  }
+
+  return (key: string) => (key ? (byName.get(key) ?? null) : null)
+}
+
+/**
+ * Returns the ISO calendar window `[start, end]` (inclusive) for a fiscal year + month.
+ *
+ * `PENDING HUMAN DETERMINATION`: assumes `fiscalYear`/`month` are calendar-aligned
+ * (month = calendar month of `fiscalYear`). Fiscal-year-start handling is out of scope.
+ */
+export function periodWindow(fiscalYear: number, month: number): { start: string; end: string } {
+  const start = new Date(Date.UTC(fiscalYear, month - 1, 1))
+  const end = new Date(Date.UTC(fiscalYear, month, 0))
+  return { start: toIsoDate(start), end: toIsoDate(end) }
+}
+
+function toIsoDate(d: Date): string {
+  return d.toISOString().slice(0, 10)
+}
+
+/**
+ * Resolves each journal to the P&L account(s) it touches within the period, grouping by
+ * canonical accountCode. A journal is emitted to a side only if that side's account
+ * resolves to a P&L account in scope (revenue/cost_of_sales/sga_expense); the other side
+ * is typically a balance-sheet account (cash, payables) and is ignored. A journal touching
+ * two P&L accounts (e.g. a reclassification) is emitted to both with opposite sides, so it
+ * nets to zero across the pair (proposal §6.3 reclass edge case). Journals resolving to no
+ * P&L account are counted as `unmatched`.
+ *
+ * @param journals - Raw journal rows (READ-ONLY).
+ * @param resolver - Account-key resolver from `buildAccountResolver`.
+ * @param fiscalYear - Fiscal year (calendar-aligned).
+ * @param month - Period month (1-12).
+ * @returns Grouped journals by accountCode + the unmatched count.
+ */
+export function resolveJournalsToAccounts(params: {
+  journals: JournalRow[]
+  resolver: AccountResolver
+  fiscalYear: number
+  month: number
+}): {
+  byAccount: Map<string, { resolution: AccountResolution; journals: JournalEntry[] }>
+  unmatched: number
+} {
+  const { journals, resolver, fiscalYear, month } = params
+  const window = periodWindow(fiscalYear, month)
+  const byAccount = new Map<string, { resolution: AccountResolution; journals: JournalEntry[] }>()
+  let unmatched = 0
+
+  for (const j of journals) {
+    const iso = toIsoDate(j.entryDate)
+    if (iso < window.start || iso > window.end) continue
+
+    const debit = resolver(j.debitAccount)
+    const credit = resolver(j.creditAccount)
+    let emitted = false
+
+    if (debit) {
+      pushJournal(byAccount, debit, {
+        journalId: j.id,
+        freeeJournalId: j.freeeJournalId,
+        entryDate: iso,
+        description: j.description,
+        amount: j.amount,
+        side: 'debit',
+      })
+      emitted = true
+    }
+    if (credit) {
+      pushJournal(byAccount, credit, {
+        journalId: j.id,
+        freeeJournalId: j.freeeJournalId,
+        entryDate: iso,
+        description: j.description,
+        amount: j.amount,
+        side: 'credit',
+      })
+      emitted = true
+    }
+    if (!emitted) unmatched += 1
+  }
+
+  return { byAccount, unmatched }
+}
+
+function pushJournal(
+  byAccount: Map<string, { resolution: AccountResolution; journals: JournalEntry[] }>,
+  resolution: AccountResolution,
+  entry: JournalEntry
+): void {
+  const existing = byAccount.get(resolution.accountCode)
+  if (existing) {
+    existing.journals.push(entry)
+  } else {
+    byAccount.set(resolution.accountCode, { resolution, journals: [entry] })
+  }
+}
+
+/**
+ * Builds the pure-core `AttributionInput` from loaded data: aggregates budgets by
+ * accountCode (summing across departments), resolves journals to accounts, and unions
+ * actuals ∪ budgets into the per-account input list. Pure (no Prisma) so it is unit-tested
+ * with plain arrays.
+ *
+ * `PENDING HUMAN DETERMINATION`: journal attribution is company-wide — `Journal` has no
+ * `departmentId`/segment (proposal §4.3), so a `departmentId` filter applies to budgets
+ * only and cannot scope the journals. Department-level variance is therefore not feasible
+ * on persisted data; the default is company-wide (departmentId undefined).
+ */
+export function prepareAttributionInput(params: {
+  actuals: ProfitLoss
+  budgets: BudgetRow[]
+  journals: JournalRow[]
+  accountItems?: AccountItemRow[]
+  fiscalYear: number
+  month: number
+  departmentId?: string | null
+  actualsSource?: ActualsSource
+}): AttributionInput {
+  const {
+    actuals,
+    budgets,
+    journals,
+    accountItems,
+    fiscalYear,
+    month,
+    departmentId,
+    actualsSource = 'monthly_balance',
+  } = params
+
+  const deptFilter = departmentId ?? ''
+  const scopedBudgets =
+    departmentId !== undefined
+      ? budgets.filter((b) => (b.departmentId ?? '') === deptFilter)
+      : budgets
+
+  const budgetByCode = new Map<
+    string,
+    { accountCode: string; accountName: string; amount: number }
+  >()
+  for (const b of scopedBudgets) {
+    const existing = budgetByCode.get(b.accountCode)
+    if (existing) {
+      existing.amount += b.amount
+    } else {
+      budgetByCode.set(b.accountCode, {
+        accountCode: b.accountCode,
+        accountName: b.accountName,
+        amount: b.amount,
+      })
+    }
+  }
+
+  const resolver = buildAccountResolver({
+    actuals,
+    budgets: [...budgetByCode.values()],
+    accountItems,
+  })
+  const { byAccount, unmatched } = resolveJournalsToAccounts({
+    journals,
+    resolver,
+    fiscalYear,
+    month,
+  })
+
+  const accounts: AccountAttributionInput[] = []
+  const seen = new Set<string>()
+
+  const push = (code: string, name: string, category: PlCategory, actual: number) => {
+    if (seen.has(code)) return
+    seen.add(code)
+    accounts.push({
+      accountCode: code,
+      accountName: name,
+      category,
+      budget: budgetByCode.get(code)?.amount ?? 0,
+      actual,
+      journals: byAccount.get(code)?.journals ?? [],
+    })
+  }
+
+  for (const r of actuals.revenue) push(r.code, r.name, 'revenue', r.amount)
+  for (const c of actuals.costOfSales) push(c.code, c.name, 'cost_of_sales', c.amount)
+  for (const e of actuals.sgaExpenses) push(e.code, e.name, 'sga_expense', e.amount)
+
+  for (const b of budgetByCode.values()) {
+    const category = inferCategoryFromCode(b.accountCode)
+    if (category === null) continue // non-P&L budget: not attributable
+    push(b.accountCode, b.accountName, category, 0)
+  }
+
+  return {
+    fiscalYear,
+    month,
+    actualsSource,
+    accounts,
+    unmatchedJournalCount: unmatched,
+  }
+}
+
+/**
+ * Loads Budget + Journal + AccountItem (READ-ONLY) for a company/period and computes the
+ * full variance attribution via the pure core. Journals and ledger data are read-only
+ * inputs; all computation is in the non-Class-A budget service.
+ *
+ * @param params - Company id, fiscal year, month, actual P&L, attribution options, and an
+ *   optional `departmentId` (budgets-only filter; journals stay company-wide) and
+ *   `actualsSource` (default `monthly_balance`; set `sample`/`mock` when feeding synthetic
+ *   P&L so the data-quality warning fires).
+ * @returns `success(VarianceAttribution)` or `failure(AppError)` on validation/DB error.
+ */
+export async function computeVarianceAttribution(params: {
+  companyId: string
+  fiscalYear: number
+  month: number
+  actuals: ProfitLoss
+  options?: AttributionOptions
+  departmentId?: string | null
+  actualsSource?: ActualsSource
+}): Promise<Result<VarianceAttribution, AppError>> {
+  const { companyId, fiscalYear, month, actuals, options, departmentId, actualsSource } = params
+
+  if (!companyId) {
+    return failure(createAppError(ERROR_CODES.VALIDATION_ERROR, 'companyId is required'))
+  }
+  if (!Number.isInteger(month) || month < 1 || month > 12) {
+    return failure(createAppError(ERROR_CODES.VALIDATION_ERROR, 'month must be an integer 1-12'))
+  }
+  if (!Number.isInteger(fiscalYear)) {
+    return failure(createAppError(ERROR_CODES.VALIDATION_ERROR, 'fiscalYear must be an integer'))
+  }
+
+  const window = periodWindow(fiscalYear, month)
+  const loadResult = await tryCatch(async () => {
+    const [budgets, journals, accountItems] = await Promise.all([
+      getBudgetsByMonth(companyId, fiscalYear, month),
+      prisma.journal.findMany({
+        where: {
+          companyId,
+          entryDate: {
+            gte: new Date(window.start + 'T00:00:00.000Z'),
+            lte: new Date(window.end + 'T23:59:59.999Z'),
+          },
+        },
+      }),
+      prisma.accountItem.findMany({ where: { companyId } }),
+    ])
+    return { budgets, journals, accountItems }
+  }, ERROR_CODES.DATABASE_ERROR)
+  if (!loadResult.success) return loadResult
+
+  const { budgets, journals, accountItems } = loadResult.data
+  const input = prepareAttributionInput({
+    actuals,
+    budgets: budgets.map((b) => ({
+      accountCode: b.accountCode,
+      accountName: b.accountName,
+      amount: b.amount,
+      departmentId: b.departmentId,
+    })),
+    journals: journals.map((j) => ({
+      id: j.id,
+      freeeJournalId: j.freeeJournalId,
+      entryDate: j.entryDate,
+      description: j.description,
+      debitAccount: j.debitAccount,
+      creditAccount: j.creditAccount,
+      amount: j.amount,
+    })),
+    accountItems: accountItems.map((a) => ({
+      name: a.name,
+      shortcut: a.shortcut,
+      shortcutNum: a.shortcutNum,
+      freeeId: a.freeeId,
+      categoryType: a.categoryType,
+    })),
+    fiscalYear,
+    month,
+    departmentId,
+    actualsSource,
+  })
+
+  return attributeVariance(input, options)
+}

--- a/src/services/budget/variance-attribution.ts
+++ b/src/services/budget/variance-attribution.ts
@@ -1,0 +1,707 @@
+import { z } from 'zod'
+import {
+  success,
+  failure,
+  createAppError,
+  ERROR_CODES,
+  type Result,
+  type AppError,
+} from '@/types/result'
+
+/**
+ * FIN-IMPL-01 — Journal-level budget-variance attribution (予実要因分析).
+ *
+ * Implements the methodology in docs/proposals/fin-design-01-variance-attribution.md:
+ *   - Layer A: per-account static-budget variance decomposed into a computable driver
+ *     taxonomy (timing / outlier / run_rate / new_unbudgeted / absence / unreconciled /
+ *     immaterial).
+ *   - Layer B: per-account journal ranking by deviation from an expected amount (M0
+ *     uniform spread), with contributions that reconcile to the account variance.
+ *
+ * Standard variance-analysis framework: Horngren, Datar & Rajan, *Cost Accounting: A
+ * Managerial Emphasis*; Garrison, Noreen & Brewer, *Managerial Accounting* (Level 1
+ * static-budget variance; Level 2 flexible/activity; Level 3 price/efficiency; revenue
+ * price/volume/mix). Only the Level-1 + journal-deviation layer is computable from
+ * persisted data; Levels 2/3 and full PVVM require quantity/unit-price + partner/segment
+ * dimensions that the Journal model does not store (proposal §4.3, §7.1–7.2) and are
+ * therefore `PENDING HUMAN DETERMINATION`.
+ *
+ * This module is the PURE attribution core. It performs no I/O and imports no Prisma
+ * client; all data (actuals, budgets, journals already resolved to an account + side)
+ * is passed in. The async DB loader lives in `variance-attribution-loader.ts`.
+ *
+ * Reconciliation identity (proposal §6.5), enforced by construction:
+ *   `StaticVariance_a = (Σ deviation_j) + ReconciliationGap_a`
+ * where `deviation_j = signedAmount_j − expected_j`, `expected_j = Budget_a / |J_a|`
+ * (M0, so Σ expected_j = Budget_a when |J_a| > 0), and
+ * `ReconciliationGap_a = Actual_a − Σ signedAmount_j`. Every driver `amount` therefore
+ * sums (with `unreconciled`) to `variance`.
+ */
+
+// ---------------------------------------------------------------------------
+// Sign convention (proposal §3, §6.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * P&L direction of an account. Drives the favorable/unfavorable classification:
+ *   - `revenue`: favorable when `actual > budget` (over budget is good).
+ *   - `expense`: favorable when `actual < budget` (under budget is good).
+ *
+ * `PENDING HUMAN DETERMINATION`: the existing services label variances "over/under" by
+ * raw sign only, which is ambiguous for expenses (an expense over-run is unfavorable but
+ * coded identically to a favorable revenue over-run). This classification corrects that.
+ */
+export type SignConvention = 'revenue' | 'expense'
+
+/**
+ * Classifies an account's category into its P&L sign convention. Revenue accounts are
+ * favorable when actual exceeds budget; cost-of-sales and SGA expenses are favorable
+ * when actual is below budget.
+ *
+ * @param category - P&L category (`revenue` | `cost_of_sales` | `sga_expense`).
+ * @returns `revenue` for revenue accounts, `expense` otherwise.
+ */
+export function signConventionForCategory(
+  category: 'revenue' | 'cost_of_sales' | 'sga_expense'
+): SignConvention {
+  return category === 'revenue' ? 'revenue' : 'expense'
+}
+
+/**
+ * Classifies a variance as favorable / unfavorable / neutral per the standard sign
+ * convention (proposal §3, §6.2). A variance is *favorable (F)* when it increases
+ * operating income relative to budget; *unfavorable (U)* otherwise.
+ *
+ * @param actual - Actual amount for the account/period.
+ * @param budget - Budgeted amount for the account/period.
+ * @param signConvention - P&L direction of the account.
+ * @returns `true` (favorable), `false` (unfavorable), or `null` (zero variance).
+ */
+export function classifyFavorable(
+  actual: number,
+  budget: number,
+  signConvention: SignConvention
+): boolean | null {
+  const variance = actual - budget
+  if (variance === 0) return null
+  if (signConvention === 'revenue') return variance > 0
+  return variance < 0
+}
+
+/**
+ * Signs a journal amount to the account's natural P&L direction (proposal §6.4 step 1).
+ *
+ * Double-entry convention: a *credit* to a revenue account increases revenue; a *debit*
+ * to an expense account increases expense. `signedAmount` is therefore positive when the
+ * journal increases the account's P&L magnitude and negative when it decreases it (e.g.
+ * a sales return debiting revenue, or an expense rebate crediting an expense). With this
+ * signing, `Σ signedAmount_j ≈ Actual_a` (the residual is the reconciliation gap, §6.5).
+ *
+ * @param amount - Raw journal amount (always a positive magnitude on the Journal row).
+ * @param side - Which side of the journal resolves to the account being attributed.
+ * @param signConvention - P&L direction of the account.
+ * @returns The signed amount in the account's natural direction.
+ */
+export function signJournalAmount(
+  amount: number,
+  side: 'debit' | 'credit',
+  signConvention: SignConvention
+): number {
+  if (signConvention === 'revenue') return side === 'credit' ? amount : -amount
+  return side === 'debit' ? amount : -amount
+}
+
+// ---------------------------------------------------------------------------
+// Expected-amount model M0 (proposal §6.4 step 2, model M0)
+// ---------------------------------------------------------------------------
+
+/**
+ * M0 (uniform spread) expected amount per journal: `Budget_a / |J_a|`. This is the only
+ * zero-data expected-amount model; M1 (temporal), M2 (prior-year), and M3 (driver-based
+ * PVVM) require dimensions the Journal model does not persist and are
+ * `PENDING HUMAN DETERMINATION`.
+ *
+ * @param budget - Budgeted amount for the account.
+ * @param journalCount - Number of journals resolved to the account in the period.
+ * @returns Expected amount per journal, or `0` when there are no journals.
+ */
+export function expectedAmountUniform(budget: number, journalCount: number): number {
+  if (journalCount <= 0) return 0
+  return budget / journalCount
+}
+
+// ---------------------------------------------------------------------------
+// Outlier detection (z-score, proposal §6.1, §6.4 step 3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes population z-scores for a set of values. Returns `null` per entry when the
+ * distribution has fewer than 2 points or zero standard deviation (an outlier cannot be
+ * defined on a degenerate distribution).
+ *
+ * `PENDING HUMAN DETERMINATION`: population (n) vs sample (n−1) standard deviation, and
+ * the outlier threshold (default 2.5). Defaults are conservative starting points.
+ *
+ * @param values - Signed journal amounts for one account.
+ * @returns Z-score per value, or `null` where undefined.
+ */
+export function computeZScores(values: number[]): (number | null)[] {
+  const n = values.length
+  if (n < 2) return values.map(() => null)
+  const mean = values.reduce((sum, v) => sum + v, 0) / n
+  const variance = values.reduce((sum, v) => sum + (v - mean) * (v - mean), 0) / n
+  const sigma = Math.sqrt(variance)
+  if (sigma === 0) return values.map(() => null)
+  return values.map((v) => (v - mean) / sigma)
+}
+
+// ---------------------------------------------------------------------------
+// Materiality (proposal §6.2)
+// ---------------------------------------------------------------------------
+
+/**
+ * Materiality threshold: `max(absoluteFloor, pctOfRevenue × totalRevenue)`. Variances
+ * below this are aggregated into a single `immaterial` bucket and not exploded to
+ * journals. `PENDING HUMAN DETERMINATION` on the floor and percentage.
+ *
+ * @param totalRevenue - Total actual revenue across revenue accounts (materiality base).
+ * @param opts - Resolved attribution options.
+ * @returns The materiality threshold (currency units).
+ */
+export function materialityThreshold(
+  totalRevenue: number,
+  opts: Required<AttributionOptions>
+): number {
+  return Math.max(opts.materialityAbsoluteFloor, opts.materialityPctOfRevenue * totalRevenue)
+}
+
+// ---------------------------------------------------------------------------
+// Timing / period-boundary detection (proposal §6.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detects whether a journal's entry date is on the first or last day of the attributed
+ * period (cut-off / period-boundary signal, proposal §6.3). Reversing-pair detection is
+ * `PENDING HUMAN DETERMINATION` and not implemented; only the boundary heuristic is used.
+ *
+ * `PENDING HUMAN DETERMINATION`: assumes `fiscalYear`/`month` are calendar-aligned
+ * (month = calendar month of `fiscalYear`). Fiscal-year-start handling is out of scope.
+ *
+ * @param entryDate - ISO date string `yyyy-mm-dd`.
+ * @param fiscalYear - Fiscal year (assumed calendar-aligned).
+ * @param month - Period month (1-12).
+ * @returns `true` if the date is the first or last calendar day of the period.
+ */
+export function isPeriodBoundary(entryDate: string, fiscalYear: number, month: number): boolean {
+  const parts = entryDate.slice(0, 10).split('-')
+  if (parts.length !== 3) return false
+  const y = Number(parts[0])
+  const m = Number(parts[1])
+  const d = Number(parts[2])
+  if (!Number.isFinite(y) || !Number.isFinite(m) || !Number.isFinite(d)) return false
+  if (y !== fiscalYear || m !== month) return false
+  const lastDay = new Date(Date.UTC(y, m, 0)).getUTCDate()
+  return d === 1 || d === lastDay
+}
+
+// ---------------------------------------------------------------------------
+// Driver taxonomy (proposal §6.1, §6.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * Named variance drivers. The full price/volume/mix split is NOT computable on persisted
+ * data (no quantity/unit-price or partner dimension); the combined volume×price effect
+ * that cannot be split is reported as the `run_rate` residual.
+ */
+export type VarianceDriver =
+  | 'timing'
+  | 'outlier'
+  | 'run_rate'
+  | 'new_unbudgeted'
+  | 'absence'
+  | 'unreconciled'
+  | 'immaterial'
+
+/**
+ * Classifies a single journal's driver tag. Precedence: `new_unbudgeted` (account has no
+ * budget) > `outlier` (|z| ≥ threshold) > `timing` (period-boundary date) > `run_rate`
+ * (residual). `PENDING HUMAN DETERMINATION` on this precedence ordering.
+ *
+ * @param params - z-score, boundary flag, and whether the account has a zero budget.
+ * @param opts - Resolved attribution options.
+ * @returns The driver tag for the journal.
+ */
+export function classifyJournalDriver(
+  params: { zScore: number | null; isBoundary: boolean; budgetZero: boolean },
+  opts: Required<AttributionOptions>
+): VarianceDriver {
+  if (params.budgetZero) return 'new_unbudgeted'
+  if (params.zScore !== null && Math.abs(params.zScore) >= opts.outlierZThreshold) {
+    return 'outlier'
+  }
+  if (params.isBoundary) return 'timing'
+  return 'run_rate'
+}
+
+// ---------------------------------------------------------------------------
+// Input schemas (Zod) — validated with safeParse (proposal: Result + Zod)
+// ---------------------------------------------------------------------------
+
+const JournalEntrySchema = z.object({
+  journalId: z.string().min(1),
+  freeeJournalId: z.string().nullable().optional(),
+  entryDate: z.string().min(1),
+  description: z.string(),
+  amount: z.number(),
+  /** Which side of the double-entry journal resolves to the account being attributed. */
+  side: z.enum(['debit', 'credit']),
+})
+
+const AccountAttributionInputSchema = z.object({
+  accountCode: z.string().min(1),
+  accountName: z.string(),
+  category: z.enum(['revenue', 'cost_of_sales', 'sga_expense']),
+  budget: z.number(),
+  actual: z.number(),
+  /** Journals already resolved to this account (by the loader's account-key crosswalk). */
+  journals: z.array(JournalEntrySchema),
+})
+
+const AttributionInputSchema = z.object({
+  fiscalYear: z.number().int(),
+  month: z.number().int().min(1).max(12),
+  actualsSource: z.enum(['monthly_balance', 'sample', 'mock', 'none']),
+  accounts: z.array(AccountAttributionInputSchema),
+  unmatchedJournalCount: z.number().int().nonnegative().optional(),
+  warnings: z.array(z.string()).optional(),
+})
+
+/** A journal already resolved to one account + side (input to the pure core). */
+export type JournalEntry = z.infer<typeof JournalEntrySchema>
+
+/** A single account's inputs for attribution (input to the pure core). */
+export type AccountAttributionInput = z.infer<typeof AccountAttributionInputSchema>
+
+/** Top-level input to `attributeVariance`. */
+export type AttributionInput = z.infer<typeof AttributionInputSchema>
+
+/** Source of the actuals fed into attribution (proposal §8 `dataQuality.actualsSource`). */
+export type ActualsSource = AttributionInput['actualsSource']
+
+/**
+ * Attribution options. All thresholds are `PENDING HUMAN DETERMINATION` (proposal §6.2,
+ * §11.5); defaults are conservative starting points for a human reviewer to tune.
+ */
+export interface AttributionOptions {
+  /** Max journals returned per account, ranked by |deviation|. */
+  topK?: number
+  /** Absolute materiality floor (currency). Variances below `max(floor, pct×revenue)`. */
+  materialityAbsoluteFloor?: number
+  /** Materiality as a fraction of total revenue. */
+  materialityPctOfRevenue?: number
+  /** |z| at/above which a journal is tagged `outlier`. */
+  outlierZThreshold?: number
+  /** Unreconciled share above which journal-attribution confidence degrades to `low`. */
+  unreconciledTolerancePct?: number
+  /** Expected-amount model. Only `M0` (uniform spread) is implemented. */
+  expectedModel?: 'M0'
+}
+
+const DEFAULT_OPTIONS: Required<AttributionOptions> = {
+  topK: 10,
+  materialityAbsoluteFloor: 10000,
+  materialityPctOfRevenue: 0.005,
+  outlierZThreshold: 2.5,
+  unreconciledTolerancePct: 0.1,
+  expectedModel: 'M0',
+}
+
+function resolveOptions(options?: AttributionOptions): Required<AttributionOptions> {
+  return { ...DEFAULT_OPTIONS, ...options }
+}
+
+// ---------------------------------------------------------------------------
+// Output types (proposal §8 response shape)
+// ---------------------------------------------------------------------------
+
+export interface DriverBreakdown {
+  driver: VarianceDriver
+  /** Signed contribution to the account variance; Σ across drivers (incl. unreconciled) = variance. */
+  amount: number
+  /** `amount / variance × 100` (signed); `null` when variance is zero. */
+  pctOfVariance: number | null
+  journalsCount: number
+}
+
+export interface JournalAttribution {
+  journalId: string
+  freeeJournalId: string | null
+  entryDate: string
+  description: string
+  /** Signed to the account's P&L direction (proposal §6.4 step 1). */
+  signedAmount: number
+  /** Expected amount (M0: `budget / |J_a|`). */
+  expected: number
+  /** `signedAmount − expected`; Σ + unreconciled = variance. */
+  deviation: number
+  /** `deviation / variance × 100` (signed); `null` when variance is zero. */
+  contributionPct: number | null
+  zScore: number | null
+  driver: VarianceDriver
+  direction: 'favorable' | 'unfavorable' | 'neutral'
+}
+
+export interface Reconciliation {
+  journalSum: number
+  actual: number
+  /** `actual − journalSum` (proposal §6.5 reconciliation gap). */
+  unreconciled: number
+  /** `unreconciled / max(|actual|, |journalSum|) × 100`; `null` when the denominator is zero. */
+  unreconciledPct: number | null
+}
+
+export interface AccountAttribution {
+  accountCode: string
+  accountName: string
+  category: 'revenue' | 'cost_of_sales' | 'sga_expense'
+  signConvention: SignConvention
+  budget: number
+  actual: number
+  /** `actual − budget` (Level 1 static-budget variance, proposal §3). */
+  variance: number
+  /** `variance / budget × 100`; `null` when budget is zero (proposal §6.2). */
+  variancePct: number | null
+  favorable: boolean | null
+  material: boolean
+  /** `actual / budget × 100`; `null` when budget is zero (proposal §6.2). */
+  achievementRate: number | null
+  reconciliation: Reconciliation
+  drivers: DriverBreakdown[]
+  journals: JournalAttribution[]
+  journalAttributionConfidence: 'high' | 'low'
+}
+
+export interface VarianceAttributionDataQuality {
+  actualsSource: ActualsSource
+  /** `% of actual-bearing accounts that have a budget` (proposal §8). */
+  budgetCoveragePct: number
+  /** All `false`: Journal stores no partner/segment/quantity (proposal §4.3). */
+  dimensionCoverage: { partner: boolean; segment: boolean; quantity: boolean }
+  warnings: string[]
+  unmatchedJournalCount: number
+}
+
+export interface VarianceAttribution {
+  fiscalYear: number
+  month: number
+  dataQuality: VarianceAttributionDataQuality
+  accounts: AccountAttribution[]
+  summary: {
+    /** Operating-income level: `Σ revenue − Σ (cost_of_sales + sga_expense)`, budgets. */
+    totalBudget: number
+    totalActual: number
+    totalVariance: number
+    favorable: boolean | null
+    /** Signed sum of immaterial-account variances (proposal §8). */
+    immaterialBucket: number
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-account attribution (Layer A + Layer B)
+// ---------------------------------------------------------------------------
+
+function attributeAccount(
+  acc: AccountAttributionInput,
+  ctx: {
+    fiscalYear: number
+    month: number
+    totalRevenue: number
+    opts: Required<AttributionOptions>
+  }
+): AccountAttribution {
+  const { fiscalYear, month, totalRevenue, opts } = ctx
+  const signConvention = signConventionForCategory(acc.category)
+  const variance = acc.actual - acc.budget
+  const favorable = classifyFavorable(acc.actual, acc.budget, signConvention)
+  const threshold = materialityThreshold(totalRevenue, opts)
+  const material = Math.abs(variance) >= threshold
+  const achievementRate = acc.budget !== 0 ? (acc.actual / acc.budget) * 100 : null
+  const variancePct = acc.budget !== 0 ? (variance / acc.budget) * 100 : null
+
+  const signedJournals = acc.journals.map((j) => ({
+    ...j,
+    signedAmount: signJournalAmount(j.amount, j.side, signConvention),
+  }))
+  const journalSum = signedJournals.reduce((sum, j) => sum + j.signedAmount, 0)
+  const unreconciled = acc.actual - journalSum
+  const reconDenom = Math.max(Math.abs(acc.actual), Math.abs(journalSum))
+  const unreconciledPct = reconDenom !== 0 ? (unreconciled / reconDenom) * 100 : null
+  const confidenceDenom = Math.max(Math.abs(acc.actual), Math.abs(acc.budget), 1)
+  const unreconciledShare = Math.abs(unreconciled) / confidenceDenom
+  const journalAttributionConfidence: 'high' | 'low' =
+    unreconciledShare > opts.unreconciledTolerancePct ? 'low' : 'high'
+
+  const reconciliation: Reconciliation = {
+    journalSum,
+    actual: acc.actual,
+    unreconciled,
+    unreconciledPct,
+  }
+
+  // Immaterial variances are aggregated, not exploded to journals (proposal §6.2).
+  if (!material) {
+    return {
+      accountCode: acc.accountCode,
+      accountName: acc.accountName,
+      category: acc.category,
+      signConvention,
+      budget: acc.budget,
+      actual: acc.actual,
+      variance,
+      variancePct,
+      favorable,
+      material,
+      achievementRate,
+      reconciliation,
+      drivers: [
+        {
+          driver: 'immaterial',
+          amount: variance,
+          pctOfVariance: variance === 0 ? null : 100,
+          journalsCount: 0,
+        },
+      ],
+      journals: [],
+      journalAttributionConfidence: 'high',
+    }
+  }
+
+  // No journals resolved to this account.
+  if (signedJournals.length === 0) {
+    // PENDING HUMAN DETERMINATION: boundary between `absence` (budgeted, ≈ no actual)
+    // and `unreconciled` (actual present but no journal backing). Default: actual below
+    // the materiality floor is treated as absence; otherwise the whole variance is
+    // unreconciled (no journals to attribute).
+    const isAbsence = Math.abs(acc.actual) < opts.materialityAbsoluteFloor
+    const driver: VarianceDriver = isAbsence ? 'absence' : 'unreconciled'
+    return {
+      accountCode: acc.accountCode,
+      accountName: acc.accountName,
+      category: acc.category,
+      signConvention,
+      budget: acc.budget,
+      actual: acc.actual,
+      variance,
+      variancePct,
+      favorable,
+      material,
+      achievementRate,
+      reconciliation,
+      drivers: [{ driver, amount: variance, pctOfVariance: 100, journalsCount: 0 }],
+      journals: [],
+      // No journals to attribute → journal-level confidence is low by definition.
+      journalAttributionConfidence: 'low',
+    }
+  }
+
+  // Material + has journals: M0 expected + driver decomposition + ranking.
+  const n = signedJournals.length
+  const expected = expectedAmountUniform(acc.budget, n)
+  const zScores = computeZScores(signedJournals.map((j) => j.signedAmount))
+  const budgetZero = acc.budget === 0
+
+  const journalAttributions: JournalAttribution[] = signedJournals.map((j, i) => {
+    const z = zScores[i]
+    const deviation = j.signedAmount - expected
+    const driver = classifyJournalDriver(
+      {
+        zScore: z,
+        isBoundary: isPeriodBoundary(j.entryDate, fiscalYear, month),
+        budgetZero,
+      },
+      opts
+    )
+    const direction: 'favorable' | 'unfavorable' | 'neutral' =
+      deviation === 0
+        ? 'neutral'
+        : signConvention === 'revenue'
+          ? deviation > 0
+            ? 'favorable'
+            : 'unfavorable'
+          : deviation > 0
+            ? 'unfavorable'
+            : 'favorable'
+    return {
+      journalId: j.journalId,
+      freeeJournalId: j.freeeJournalId ?? null,
+      entryDate: j.entryDate,
+      description: j.description,
+      signedAmount: j.signedAmount,
+      expected,
+      deviation,
+      contributionPct: variance !== 0 ? (deviation / variance) * 100 : null,
+      zScore: z,
+      driver,
+      direction,
+    }
+  })
+
+  // Driver roll-up: Σ deviation by driver tag. With `unreconciled`, sums to `variance`
+  // (proposal §6.4 step 5, §6.5 identity).
+  const driverAmounts = new Map<VarianceDriver, number>()
+  const driverCounts = new Map<VarianceDriver, number>()
+  for (const j of journalAttributions) {
+    driverAmounts.set(j.driver, (driverAmounts.get(j.driver) ?? 0) + j.deviation)
+    driverCounts.set(j.driver, (driverCounts.get(j.driver) ?? 0) + 1)
+  }
+  const drivers: DriverBreakdown[] = []
+  for (const [driver, amount] of driverAmounts) {
+    drivers.push({
+      driver,
+      amount,
+      pctOfVariance: variance !== 0 ? (amount / variance) * 100 : null,
+      journalsCount: driverCounts.get(driver) ?? 0,
+    })
+  }
+  drivers.push({
+    driver: 'unreconciled',
+    amount: unreconciled,
+    pctOfVariance: variance !== 0 ? (unreconciled / variance) * 100 : null,
+    journalsCount: 0,
+  })
+  drivers.sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount))
+
+  const ranked = [...journalAttributions]
+    .sort((a, b) => Math.abs(b.deviation) - Math.abs(a.deviation))
+    .slice(0, opts.topK)
+
+  return {
+    accountCode: acc.accountCode,
+    accountName: acc.accountName,
+    category: acc.category,
+    signConvention,
+    budget: acc.budget,
+    actual: acc.actual,
+    variance,
+    variancePct,
+    favorable,
+    material,
+    achievementRate,
+    reconciliation,
+    drivers,
+    journals: ranked,
+    journalAttributionConfidence,
+  }
+}
+
+function sumOperatingIncome(
+  accounts: AccountAttributionInput[],
+  pick: (a: AccountAttributionInput) => number
+): number {
+  let sum = 0
+  for (const a of accounts) {
+    sum += a.category === 'revenue' ? pick(a) : -pick(a)
+  }
+  return sum
+}
+
+// ---------------------------------------------------------------------------
+// Top-level entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Attributes per-account budget variance to named drivers and ranked journal entries
+ * (proposal §5, §6, §9). Pure: no I/O. Input is validated with Zod `safeParse`; invalid
+ * input yields a `failure` Result.
+ *
+ * @param input - Fiscal year/month, actuals source, and per-account inputs (each with its
+ *   journals already resolved to the account + side by the loader).
+ * @param options - Attribution thresholds (all `PENDING HUMAN DETERMINATION`).
+ * @returns `success(VarianceAttribution)` or `failure(AppError)`.
+ */
+export function attributeVariance(
+  input: AttributionInput,
+  options?: AttributionOptions
+): Result<VarianceAttribution, AppError> {
+  const opts = resolveOptions(options)
+  if (opts.expectedModel !== 'M0') {
+    return failure(
+      createAppError(
+        ERROR_CODES.BUSINESS_LOGIC_ERROR,
+        `Expected-amount model '${opts.expectedModel}' is not implemented (PENDING HUMAN DETERMINATION). Only M0 (uniform spread) is available.`
+      )
+    )
+  }
+
+  const parsed = AttributionInputSchema.safeParse(input)
+  if (!parsed.success) {
+    return failure(
+      createAppError(
+        ERROR_CODES.VALIDATION_ERROR,
+        'Variance attribution input validation failed.',
+        {
+          details: { issues: parsed.error.issues },
+        }
+      )
+    )
+  }
+  const data = parsed.data
+
+  const totalRevenue = data.accounts
+    .filter((a) => a.category === 'revenue')
+    .reduce((sum, a) => sum + Math.abs(a.actual), 0)
+  const ctx = { fiscalYear: data.fiscalYear, month: data.month, totalRevenue, opts }
+  const accounts = data.accounts.map((a) => attributeAccount(a, ctx))
+
+  const totalBudget = sumOperatingIncome(data.accounts, (a) => a.budget)
+  const totalActual = sumOperatingIncome(data.accounts, (a) => a.actual)
+  const totalVariance = totalActual - totalBudget
+  const favorable = totalVariance > 0 ? true : totalVariance < 0 ? false : null
+  const immaterialBucket = accounts
+    .filter((a) => !a.material)
+    .reduce((sum, a) => sum + a.variance, 0)
+
+  const accountsWithActual = data.accounts.filter((a) => a.actual !== 0)
+  const budgetCoveragePct =
+    accountsWithActual.length > 0
+      ? (accountsWithActual.filter((a) => a.budget !== 0).length / accountsWithActual.length) * 100
+      : 0
+
+  const warnings = new Set<string>(data.warnings ?? [])
+  if (data.accounts.some((a) => a.category === 'revenue' || a.category === 'cost_of_sales')) {
+    // Proposal §4.4: the freee-path account→category mapping is broken (revenue branch
+    // is dead code; no cost_of_sales branch). The fix is Class-A (freee integration) and
+    // out of scope, so revenue/COGS variances are flagged unverified.
+    warnings.add('category_mapping_unverified_freee_path')
+  }
+  if (data.actualsSource === 'sample' || data.actualsSource === 'mock') {
+    warnings.add('actuals_are_synthetic')
+  }
+  if ((data.unmatchedJournalCount ?? 0) > 0) {
+    warnings.add('unmatched_journals_not_attributed')
+  }
+  // Journal stores no partner/segment/quantity (proposal §4.3): full PVVM is not
+  // computable; the volume×price effect is reported as the `run_rate` residual.
+  warnings.add('pvvm_not_computable_no_dimensions')
+
+  return success({
+    fiscalYear: data.fiscalYear,
+    month: data.month,
+    dataQuality: {
+      actualsSource: data.actualsSource,
+      budgetCoveragePct,
+      dimensionCoverage: { partner: false, segment: false, quantity: false },
+      warnings: [...warnings],
+      unmatchedJournalCount: data.unmatchedJournalCount ?? 0,
+    },
+    accounts,
+    summary: {
+      totalBudget,
+      totalActual,
+      totalVariance,
+      favorable,
+      immaterialBucket,
+    },
+  })
+}

--- a/tests/unit/services/budget/detailed-actual-vs-budget.test.ts
+++ b/tests/unit/services/budget/detailed-actual-vs-budget.test.ts
@@ -300,4 +300,38 @@ describe('DetailedActualVsBudgetService', () => {
       expect(result).toBeDefined()
     })
   })
+
+  describe('favorable sign convention (proposal §6.2)', () => {
+    it('classifies stage-level variances by P&L direction', async () => {
+      vi.mocked(getBudgetsByMonth).mockResolvedValue(mockBudgets as any)
+
+      const result = await calculateDetailedActualVsBudget(mockCompanyId, 2024, 12, mockPL)
+
+      const byStage = (stage: string) => result.stageLevel.find((s) => s.stage === stage)!
+      // 売上高: actual 10M < budget 12M → revenue under budget → unfavorable.
+      expect(byStage('売上高').favorable).toBe(false)
+      // 売上原価: actual 6M < budget 7M → expense under budget → favorable.
+      expect(byStage('売上原価').favorable).toBe(true)
+      // 販売管理費: actual 2M === budget 2M → zero variance → null.
+      expect(byStage('販売管理費').favorable).toBeNull()
+      // 営業利益: actual 2M < budget 3M → profit under budget → unfavorable.
+      expect(byStage('営業利益').favorable).toBe(false)
+    })
+
+    it('classifies account-level variances by P&L direction', async () => {
+      vi.mocked(getBudgetsByMonth).mockResolvedValue(mockBudgets as any)
+
+      const result = await calculateDetailedActualVsBudget(mockCompanyId, 2024, 12, mockPL)
+
+      const byCode = (code: string) => result.accountLevel.find((a) => a.code === code)!
+      // Revenue under budget → unfavorable.
+      expect(byCode('400').favorable).toBe(false)
+      // Cost of sales under budget → favorable.
+      expect(byCode('500').favorable).toBe(true)
+      // SGA over budget (1.5M > 1.4M) → unfavorable.
+      expect(byCode('610').favorable).toBe(false)
+      // SGA under budget (0.5M < 0.6M) → favorable.
+      expect(byCode('620').favorable).toBe(true)
+    })
+  })
 })

--- a/tests/unit/services/budget/variance-attribution-loader.test.ts
+++ b/tests/unit/services/budget/variance-attribution-loader.test.ts
@@ -1,0 +1,355 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ProfitLoss } from '@/types'
+import {
+  buildAccountResolver,
+  resolveJournalsToAccounts,
+  prepareAttributionInput,
+  periodWindow,
+  inferCategoryFromCode,
+  type BudgetRow,
+  type JournalRow,
+  type AccountItemRow,
+} from '@/services/budget/variance-attribution-loader'
+import { computeVarianceAttribution } from '@/services/budget/variance-attribution-loader'
+import { getBudgetsByMonth } from '@/services/budget/budget-service'
+import { prisma } from '@/lib/db'
+
+vi.mock('@/services/budget/budget-service', () => ({
+  getBudgetsByMonth: vi.fn(),
+}))
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    journal: { findMany: vi.fn() },
+    accountItem: { findMany: vi.fn() },
+  },
+}))
+
+const actuals: ProfitLoss = {
+  fiscalYear: 2025,
+  month: 6,
+  revenue: [{ code: '400', name: '売上高', amount: 10000000 }],
+  costOfSales: [],
+  grossProfit: 10000000,
+  grossProfitMargin: 100,
+  sgaExpenses: [{ code: '600', name: '給与手当', amount: 940000 }],
+  operatingIncome: 9060000,
+  operatingMargin: 90.6,
+  nonOperatingIncome: [],
+  nonOperatingExpenses: [],
+  ordinaryIncome: 9060000,
+  extraordinaryIncome: [],
+  extraordinaryLoss: [],
+  incomeBeforeTax: 9060000,
+  incomeTax: 2718000,
+  netIncome: 6342000,
+  depreciation: 0,
+}
+
+const budgets: BudgetRow[] = [
+  { accountCode: '400', accountName: '売上高', amount: 9500000, departmentId: null },
+  { accountCode: '600', accountName: '給与手当', amount: 800000, departmentId: null },
+  { accountCode: '650', accountName: '地代家賃', amount: 200000, departmentId: null },
+  { accountCode: '810', accountName: '支払利息', amount: 50000, departmentId: null },
+]
+
+const accountItems: AccountItemRow[] = [
+  { name: '現金', shortcutNum: '111', freeeId: 111, categoryType: 'assets' },
+  { name: '未払金', shortcutNum: '211', freeeId: 211, categoryType: 'liabilities' },
+  { name: '給与手当', shortcutNum: '600', freeeId: 6000, categoryType: 'expense' },
+]
+
+const journals: JournalRow[] = [
+  {
+    id: 'j1',
+    freeeJournalId: 'fj1',
+    entryDate: new Date('2025-06-15T00:00:00.000Z'),
+    description: '給与',
+    debitAccount: '給与手当',
+    creditAccount: '現金',
+    amount: 940000,
+  },
+  {
+    id: 'j2',
+    freeeJournalId: 'fj2',
+    entryDate: new Date('2025-06-10T00:00:00.000Z'),
+    description: '家賃',
+    debitAccount: '地代家賃',
+    creditAccount: '未払金',
+    amount: 100000,
+  },
+  {
+    id: 'j3',
+    freeeJournalId: 'fj3',
+    entryDate: new Date('2025-07-05T00:00:00.000Z'),
+    description: 'out of period',
+    debitAccount: '給与手当',
+    creditAccount: '現金',
+    amount: 50000,
+  },
+  {
+    id: 'j4',
+    freeeJournalId: 'fj4',
+    entryDate: new Date('2025-06-20T00:00:00.000Z'),
+    description: 'cash sale',
+    debitAccount: '現金',
+    creditAccount: '売上高',
+    amount: 10000000,
+  },
+  {
+    id: 'j5',
+    freeeJournalId: 'fj5',
+    entryDate: new Date('2025-06-25T00:00:00.000Z'),
+    description: 'both BS',
+    debitAccount: '仮払金',
+    creditAccount: '未収入金',
+    amount: 200000,
+  },
+]
+
+describe('inferCategoryFromCode', () => {
+  it('maps P&L prefixes and rejects balance-sheet / below-the-line codes', () => {
+    expect(inferCategoryFromCode('400')).toBe('revenue')
+    expect(inferCategoryFromCode('500')).toBe('cost_of_sales')
+    expect(inferCategoryFromCode('600')).toBe('sga_expense')
+    expect(inferCategoryFromCode('710')).toBe('sga_expense')
+    expect(inferCategoryFromCode('111')).toBeNull() // asset
+    expect(inferCategoryFromCode('810')).toBeNull() // non-operating
+  })
+})
+
+describe('periodWindow', () => {
+  it('returns the inclusive calendar month window (calendar-aligned assumption)', () => {
+    expect(periodWindow(2025, 6)).toEqual({ start: '2025-06-01', end: '2025-06-30' })
+    expect(periodWindow(2024, 2)).toEqual({ start: '2024-02-01', end: '2024-02-29' }) // leap
+    expect(periodWindow(2025, 2)).toEqual({ start: '2025-02-01', end: '2025-02-28' })
+  })
+})
+
+describe('buildAccountResolver', () => {
+  const resolver = buildAccountResolver({ actuals, budgets, accountItems })
+
+  it('prefers actuals (authoritative category) over budgets and AccountItems', () => {
+    expect(resolver('売上高')).toEqual({
+      accountCode: '400',
+      accountName: '売上高',
+      category: 'revenue',
+    })
+    expect(resolver('給与手当')).toEqual({
+      accountCode: '600',
+      accountName: '給与手当',
+      category: 'sga_expense',
+    })
+  })
+
+  it('falls back to budgets for budget-only P&L accounts (prefix-inferred category)', () => {
+    expect(resolver('地代家賃')).toEqual({
+      accountCode: '650',
+      accountName: '地代家賃',
+      category: 'sga_expense',
+    })
+  })
+
+  it('rejects balance-sheet AccountItems and below-the-line budgets', () => {
+    expect(resolver('現金')).toBeNull() // AccountItem categoryType 'assets'
+    expect(resolver('未払金')).toBeNull() // 'liabilities'
+    expect(resolver('支払利息')).toBeNull() // budget code 810 → null
+  })
+
+  it('returns null for unknown account names', () => {
+    expect(resolver('存在しない勘定')).toBeNull()
+    expect(resolver('')).toBeNull()
+  })
+})
+
+describe('resolveJournalsToAccounts', () => {
+  const resolver = buildAccountResolver({ actuals, budgets, accountItems })
+  const { byAccount, unmatched } = resolveJournalsToAccounts({
+    journals,
+    resolver,
+    fiscalYear: 2025,
+    month: 6,
+  })
+
+  it('emits a one-sided P&L journal to its P&L account with the correct side', () => {
+    const pay = byAccount.get('600')!
+    expect(pay.journals).toHaveLength(1)
+    expect(pay.journals[0]).toMatchObject({ journalId: 'j1', side: 'debit', amount: 940000 })
+    expect(pay.journals[0].entryDate).toBe('2025-06-15')
+  })
+
+  it('emits revenue on the credit side', () => {
+    const rev = byAccount.get('400')!
+    expect(rev.journals).toHaveLength(1)
+    expect(rev.journals[0]).toMatchObject({ journalId: 'j4', side: 'credit', amount: 10000000 })
+  })
+
+  it('emits budget-only account journals too', () => {
+    const rent = byAccount.get('650')!
+    expect(rent.journals).toHaveLength(1)
+    expect(rent.journals[0]).toMatchObject({ journalId: 'j2', side: 'debit', amount: 100000 })
+  })
+
+  it('skips journals outside the period (not counted as unmatched)', () => {
+    // j3 is in July; it should not appear anywhere and not inflate unmatched.
+    const allJournalIds = [...byAccount.values()].flatMap((g) => g.journals.map((j) => j.journalId))
+    expect(allJournalIds).not.toContain('j3')
+  })
+
+  it('counts journals resolving to no P&L account as unmatched', () => {
+    // j5 (仮払金 / 未収入金) resolves to no P&L account.
+    expect(unmatched).toBe(1)
+  })
+})
+
+describe('prepareAttributionInput', () => {
+  it('unions actuals ∪ budgets, aggregates budgets by code, and excludes non-P&L budgets', () => {
+    const input = prepareAttributionInput({
+      actuals,
+      budgets,
+      journals,
+      accountItems,
+      fiscalYear: 2025,
+      month: 6,
+    })
+
+    const codes = input.accounts.map((a) => a.accountCode)
+    expect(codes).toEqual(['400', '600', '650']) // 810 excluded (non-P&L)
+    expect(input.unmatchedJournalCount).toBe(1)
+
+    const pay = input.accounts.find((a) => a.accountCode === '600')!
+    expect(pay.budget).toBe(800000)
+    expect(pay.actual).toBe(940000)
+    expect(pay.journals[0].side).toBe('debit')
+
+    const rev = input.accounts.find((a) => a.accountCode === '400')!
+    expect(rev.budget).toBe(9500000)
+    expect(rev.actual).toBe(10000000)
+    expect(rev.journals[0].side).toBe('credit')
+
+    // Budget-only account (no actual).
+    const rent = input.accounts.find((a) => a.accountCode === '650')!
+    expect(rent.budget).toBe(200000)
+    expect(rent.actual).toBe(0)
+    expect(rent.category).toBe('sga_expense')
+  })
+
+  it('scopes budgets to a department when departmentId is provided (journals stay company-wide)', () => {
+    const deptBudgets: BudgetRow[] = [
+      { accountCode: '600', accountName: '給与手当', amount: 500000, departmentId: 'dept-A' },
+      { accountCode: '600', accountName: '給与手当', amount: 300000, departmentId: 'dept-B' },
+    ]
+    const scoped = prepareAttributionInput({
+      actuals,
+      budgets: deptBudgets,
+      journals: [],
+      fiscalYear: 2025,
+      month: 6,
+      departmentId: 'dept-A',
+    })
+    expect(scoped.accounts.find((a) => a.accountCode === '600')!.budget).toBe(500000)
+
+    const all = prepareAttributionInput({
+      actuals,
+      budgets: deptBudgets,
+      journals: [],
+      fiscalYear: 2025,
+      month: 6,
+    })
+    // departmentId undefined → both departments summed.
+    expect(all.accounts.find((a) => a.accountCode === '600')!.budget).toBe(800000)
+  })
+
+  it('passes actualsSource through', () => {
+    const input = prepareAttributionInput({
+      actuals,
+      budgets: [],
+      journals: [],
+      fiscalYear: 2025,
+      month: 6,
+      actualsSource: 'sample',
+    })
+    expect(input.actualsSource).toBe('sample')
+  })
+})
+
+describe('computeVarianceAttribution (async, mocked DB)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('loads budgets + journals + account items and returns a success Result', async () => {
+    vi.mocked(getBudgetsByMonth).mockResolvedValue(budgets as any)
+    vi.mocked(prisma.journal.findMany).mockResolvedValue(journals as any)
+    vi.mocked(prisma.accountItem.findMany).mockResolvedValue(accountItems as any)
+
+    const result = await computeVarianceAttribution({
+      companyId: 'company-1',
+      fiscalYear: 2025,
+      month: 6,
+      actuals,
+    })
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+    const codes = result.data.accounts.map((a) => a.accountCode)
+    expect(codes).toEqual(['400', '600', '650'])
+
+    // 給与手当: actual 940,000 − budget 800,000 = 140,000 (unfavorable expense over-run).
+    const pay = result.data.accounts.find((a) => a.accountCode === '600')!
+    expect(pay.variance).toBe(140000)
+    expect(pay.favorable).toBe(false)
+    expect(pay.reconciliation.unreconciled).toBe(0) // journal sums exactly to actual
+
+    expect(result.data.dataQuality.unmatchedJournalCount).toBe(1)
+    // period filter applied to journals
+    expect(prisma.journal.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          companyId: 'company-1',
+          entryDate: {
+            gte: new Date('2025-06-01T00:00:00.000Z'),
+            lte: new Date('2025-06-30T23:59:59.999Z'),
+          },
+        }),
+      })
+    )
+  })
+
+  it('returns failure for an invalid month', async () => {
+    const result = await computeVarianceAttribution({
+      companyId: 'company-1',
+      fiscalYear: 2025,
+      month: 13,
+      actuals,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('returns failure for an empty companyId', async () => {
+    const result = await computeVarianceAttribution({
+      companyId: '',
+      fiscalYear: 2025,
+      month: 6,
+      actuals,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('returns failure when the DB load throws', async () => {
+    vi.mocked(getBudgetsByMonth).mockRejectedValue(new Error('db down'))
+    vi.mocked(prisma.journal.findMany).mockResolvedValue([])
+    vi.mocked(prisma.accountItem.findMany).mockResolvedValue([])
+
+    const result = await computeVarianceAttribution({
+      companyId: 'company-1',
+      fiscalYear: 2025,
+      month: 6,
+      actuals,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('DATABASE_ERROR')
+    }
+  })
+})

--- a/tests/unit/services/budget/variance-attribution.test.ts
+++ b/tests/unit/services/budget/variance-attribution.test.ts
@@ -1,0 +1,711 @@
+import { describe, it, expect } from 'vitest'
+import {
+  attributeVariance,
+  classifyFavorable,
+  signJournalAmount,
+  expectedAmountUniform,
+  computeZScores,
+  isPeriodBoundary,
+  classifyJournalDriver,
+  signConventionForCategory,
+  materialityThreshold,
+  type AttributionInput,
+  type AccountAttributionInput,
+  type JournalEntry,
+  type VarianceAttribution,
+} from '@/services/budget/variance-attribution'
+
+/**
+ * GOLDEN tests for the variance-attribution pure core. Every expected number below is
+ * hand-computed from the methodology in docs/proposals/fin-design-01-variance-attribution.md
+ * (§3 standard framework, §6.4 journal attribution, §6.5 reconciliation identity). No
+ * fake-green: assertions check real computed values, including the reconciliation identity
+ * `Σ driver amounts = variance` and `Σ driver pctOfVariance = 100`.
+ */
+
+const FY = 2025
+const MO = 6
+
+function expenseJournal(
+  id: string,
+  amount: number,
+  entryDate: string,
+  description = ''
+): JournalEntry {
+  return { journalId: id, freeeJournalId: id, entryDate, description, amount, side: 'debit' }
+}
+
+function revenueJournal(
+  id: string,
+  amount: number,
+  entryDate: string,
+  side: 'debit' | 'credit',
+  description = ''
+): JournalEntry {
+  return { journalId: id, freeeJournalId: id, entryDate, description, amount, side }
+}
+
+/** A revenue account with actual === budget (immaterial) used purely as the materiality base. */
+function materialityBaseRevenue(actual: number): AccountAttributionInput {
+  return {
+    accountCode: '400',
+    accountName: '売上高',
+    category: 'revenue',
+    budget: actual,
+    actual,
+    journals: [],
+  }
+}
+
+function run(input: AttributionInput): VarianceAttribution {
+  const result = attributeVariance(input)
+  if (!result.success) {
+    throw new Error(`attributeVariance failed: ${result.error.message}`)
+  }
+  return result.data
+}
+
+// ---------------------------------------------------------------------------
+describe('sign convention helpers (§3, §6.2)', () => {
+  it('classifies favorable by P&L direction', () => {
+    expect(classifyFavorable(110, 100, 'revenue')).toBe(true) // revenue over budget = F
+    expect(classifyFavorable(90, 100, 'revenue')).toBe(false) // revenue under = U
+    expect(classifyFavorable(100, 100, 'revenue')).toBeNull() // zero variance = neutral
+
+    expect(classifyFavorable(90, 100, 'expense')).toBe(true) // expense under budget = F
+    expect(classifyFavorable(110, 100, 'expense')).toBe(false) // expense over = U
+    expect(classifyFavorable(100, 100, 'expense')).toBeNull()
+  })
+
+  it('maps categories to sign conventions', () => {
+    expect(signConventionForCategory('revenue')).toBe('revenue')
+    expect(signConventionForCategory('cost_of_sales')).toBe('expense')
+    expect(signConventionForCategory('sga_expense')).toBe('expense')
+  })
+
+  it('signs journal amounts to the account natural direction', () => {
+    // Revenue: credit increases (+), debit decreases (−) e.g. sales return.
+    expect(signJournalAmount(100, 'credit', 'revenue')).toBe(100)
+    expect(signJournalAmount(100, 'debit', 'revenue')).toBe(-100)
+    // Expense: debit increases (+), credit decreases (−) e.g. rebate.
+    expect(signJournalAmount(100, 'debit', 'expense')).toBe(100)
+    expect(signJournalAmount(100, 'credit', 'expense')).toBe(-100)
+  })
+})
+
+describe('expected-amount M0 (§6.4 step 2)', () => {
+  it('spreads the budget evenly across journals', () => {
+    expect(expectedAmountUniform(800000, 25)).toBe(32000)
+    expect(expectedAmountUniform(0, 5)).toBe(0)
+  })
+  it('returns 0 when there are no journals', () => {
+    expect(expectedAmountUniform(800000, 0)).toBe(0)
+    expect(expectedAmountUniform(800000, -1)).toBe(0)
+  })
+})
+
+describe('computeZScores (§6.4 step 3)', () => {
+  it('computes population z-scores', () => {
+    // [1,2,3]: mean 2, sigma sqrt(2/3) ≈ 0.81650
+    const z = computeZScores([1, 2, 3])
+    expect(z[0]).toBeCloseTo(-1.224745, 4)
+    expect(z[1]).toBeCloseTo(0, 6)
+    expect(z[2]).toBeCloseTo(1.224745, 4)
+  })
+  it('returns null for degenerate distributions', () => {
+    expect(computeZScores([42])).toEqual([null]) // n < 2
+    expect(computeZScores([5, 5, 5])).toEqual([null, null, null]) // sigma 0
+    expect(computeZScores([])).toEqual([])
+  })
+})
+
+describe('isPeriodBoundary (§6.3)', () => {
+  it('flags first/last day of the period month', () => {
+    expect(isPeriodBoundary('2025-06-01', FY, MO)).toBe(true)
+    expect(isPeriodBoundary('2025-06-30', FY, MO)).toBe(true) // June has 30 days
+    expect(isPeriodBoundary('2025-06-15', FY, MO)).toBe(false)
+    expect(isPeriodBoundary('2025-06-25', FY, MO)).toBe(false)
+  })
+  it('rejects dates outside the period', () => {
+    expect(isPeriodBoundary('2025-07-01', FY, MO)).toBe(false) // wrong month
+    expect(isPeriodBoundary('2024-06-30', FY, MO)).toBe(false) // wrong year
+  })
+  it('handles February leap-year boundary', () => {
+    expect(isPeriodBoundary('2024-02-29', 2024, 2)).toBe(true) // 2024 is a leap year
+    expect(isPeriodBoundary('2025-02-29', 2025, 2)).toBe(false) // 2025 is not
+  })
+})
+
+describe('classifyJournalDriver (§6.1)', () => {
+  const opts = {
+    topK: 10,
+    materialityAbsoluteFloor: 10000,
+    materialityPctOfRevenue: 0.005,
+    outlierZThreshold: 2.5,
+    unreconciledTolerancePct: 0.1,
+    expectedModel: 'M0' as const,
+  }
+  it('precedence: new_unbudgeted > outlier > timing > run_rate', () => {
+    expect(classifyJournalDriver({ zScore: 5, isBoundary: true, budgetZero: true }, opts)).toBe(
+      'new_unbudgeted'
+    )
+    expect(classifyJournalDriver({ zScore: 3, isBoundary: true, budgetZero: false }, opts)).toBe(
+      'outlier'
+    )
+    expect(classifyJournalDriver({ zScore: 1, isBoundary: true, budgetZero: false }, opts)).toBe(
+      'timing'
+    )
+    expect(classifyJournalDriver({ zScore: 1, isBoundary: false, budgetZero: false }, opts)).toBe(
+      'run_rate'
+    )
+  })
+  it('null z-score never triggers outlier', () => {
+    expect(
+      classifyJournalDriver({ zScore: null, isBoundary: false, budgetZero: false }, opts)
+    ).toBe('run_rate')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GOLDEN scenario 1: summer-bonus outlier (proposal §10 worked example)
+// ---------------------------------------------------------------------------
+
+describe('GOLDEN — summer-bonus outlier (§10)', () => {
+  it('decomposes variance and ranks the bonus as the top outlier journal', () => {
+    // 24 regular payroll journals of ¥35,000 + 1 summer bonus of ¥100,000.
+    const regular: JournalEntry[] = Array.from({ length: 24 }, (_, i) =>
+      expenseJournal(`j${i}`, 35000, '2025-06-15', 'monthly payroll')
+    )
+    const bonus = expenseJournal('bonus', 100000, '2025-06-25', '夏賞与')
+
+    const input: AttributionInput = {
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '600',
+          accountName: '給与手当',
+          category: 'sga_expense',
+          budget: 800000,
+          actual: 940000,
+          journals: [...regular, bonus],
+        },
+      ],
+    }
+
+    const out = run(input)
+    const acc = out.accounts.find((a) => a.accountCode === '600')!
+
+    // Static-budget variance (Level 1): actual − budget.
+    expect(acc.variance).toBe(140000)
+    expect(acc.favorable).toBe(false) // expense over budget = unfavorable
+    expect(acc.material).toBe(true)
+    expect(acc.achievementRate).toBeCloseTo(117.5, 4)
+    expect(acc.variancePct).toBeCloseTo(17.5, 4)
+    expect(acc.signConvention).toBe('expense')
+
+    // Reconciliation: journals sum exactly to actual (no accrual gap).
+    expect(acc.reconciliation.journalSum).toBe(940000)
+    expect(acc.reconciliation.unreconciled).toBe(0)
+    expect(acc.reconciliation.unreconciledPct).toBe(0)
+    expect(acc.journalAttributionConfidence).toBe('high')
+
+    // M0 expected = budget / 25 = 32,000.
+    const expected = 32000
+    expect(acc.journals[0].expected).toBe(expected)
+
+    // Top journal is the bonus, tagged outlier.
+    expect(acc.journals[0].journalId).toBe('bonus')
+    expect(acc.journals[0].driver).toBe('outlier')
+    expect(acc.journals[0].signedAmount).toBe(100000)
+    expect(acc.journals[0].deviation).toBe(100000 - expected) // 68,000
+    expect(acc.journals[0].contributionPct).toBeCloseTo((68000 / 140000) * 100, 4) // ≈48.571%
+    expect(acc.journals[0].direction).toBe('unfavorable') // extra expense
+    // z = (100000 − 37600) / sqrt(162240000) ≈ 4.8990
+    expect(acc.journals[0].zScore).toBeCloseTo(4.899, 3)
+
+    // Driver roll-up: outlier 68,000 (1) + run_rate 72,000 (24) + unreconciled 0.
+    const byDriver = new Map(acc.drivers.map((d) => [d.driver, d]))
+    expect(byDriver.get('outlier')!.amount).toBe(68000)
+    expect(byDriver.get('outlier')!.journalsCount).toBe(1)
+    expect(byDriver.get('run_rate')!.amount).toBe(72000) // 24 × (35000 − 32000)
+    expect(byDriver.get('run_rate')!.journalsCount).toBe(24)
+    expect(byDriver.get('unreconciled')!.amount).toBe(0)
+
+    // Reconciliation identity: Σ driver amounts = variance.
+    const driverSum = acc.drivers.reduce((s, d) => s + d.amount, 0)
+    expect(driverSum).toBeCloseTo(acc.variance, 6)
+    // Σ pctOfVariance = 100 (signed).
+    const pctSum = acc.drivers.reduce((s, d) => s + (d.pctOfVariance ?? 0), 0)
+    expect(pctSum).toBeCloseTo(100, 6)
+
+    // topK cap: 25 journals → at most 10 returned.
+    expect(acc.journals.length).toBe(10)
+    // Ranking: bonus first (|deviation| 68,000), then regulars (3,000 each).
+    expect(acc.journals[0].deviation).toBe(68000)
+    expect(acc.journals[1].deviation).toBe(3000)
+
+    // Summary at operating-income level: revenue 0 variance − expense 140,000 over.
+    expect(out.summary.totalActual).toBe(10000000 - 940000)
+    expect(out.summary.totalBudget).toBe(10000000 - 800000)
+    expect(out.summary.totalVariance).toBe(-140000) // op income down → unfavorable
+    expect(out.summary.favorable).toBe(false)
+    expect(out.summary.immaterialBucket).toBe(0) // revenue variance was 0
+
+    // Data quality: revenue present → category warning; dimensions all false.
+    expect(out.dataQuality.actualsSource).toBe('monthly_balance')
+    expect(out.dataQuality.budgetCoveragePct).toBe(100)
+    expect(out.dataQuality.dimensionCoverage).toEqual({
+      partner: false,
+      segment: false,
+      quantity: false,
+    })
+    expect(out.dataQuality.warnings).toContain('category_mapping_unverified_freee_path')
+    expect(out.dataQuality.warnings).toContain('pvvm_not_computable_no_dimensions')
+    expect(out.dataQuality.unmatchedJournalCount).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GOLDEN scenario 2: reconciliation gap + signed drivers + low confidence
+// ---------------------------------------------------------------------------
+
+describe('GOLDEN — reconciliation gap & signed drivers', () => {
+  it('carries the unreconciled bucket and degrades confidence when the gap is large', () => {
+    // Budget 200,000; actual 250,000; 2 debit journals (120,000 on 06-01 boundary, 80,000 mid-month).
+    // journalSum = 200,000 → unreconciled = 50,000 (accrual not in Journal).
+    const input: AttributionInput = {
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '660',
+          accountName: '広告宣伝費',
+          category: 'sga_expense',
+          budget: 200000,
+          actual: 250000,
+          journals: [
+            expenseJournal('a', 120000, '2025-06-01'), // boundary → timing
+            expenseJournal('b', 80000, '2025-06-15'), // mid-month → run_rate
+          ],
+        },
+      ],
+    }
+
+    const acc = run(input).accounts.find((a) => a.accountCode === '660')!
+    expect(acc.variance).toBe(50000)
+    expect(acc.material).toBe(true)
+    expect(acc.reconciliation.journalSum).toBe(200000)
+    expect(acc.reconciliation.unreconciled).toBe(50000)
+    expect(acc.reconciliation.unreconciledPct).toBeCloseTo((50000 / 250000) * 100, 4) // 20%
+    expect(acc.journalAttributionConfidence).toBe('low') // 20% > 10% tolerance
+
+    // expected = 200,000 / 2 = 100,000.
+    // journal a deviation = +20,000 (timing, boundary), journal b deviation = −20,000 (run_rate).
+    const byDriver = new Map(acc.drivers.map((d) => [d.driver, d]))
+    expect(byDriver.get('timing')!.amount).toBe(20000)
+    expect(byDriver.get('run_rate')!.amount).toBe(-20000)
+    expect(byDriver.get('unreconciled')!.amount).toBe(50000)
+
+    // Signed pctOfVariance sums to 100: 40 + (−40) + 100.
+    expect(byDriver.get('timing')!.pctOfVariance).toBeCloseTo(40, 4)
+    expect(byDriver.get('run_rate')!.pctOfVariance).toBeCloseTo(-40, 4)
+    expect(byDriver.get('unreconciled')!.pctOfVariance).toBeCloseTo(100, 4)
+
+    const driverSum = acc.drivers.reduce((s, d) => s + d.amount, 0)
+    expect(driverSum).toBeCloseTo(acc.variance, 6)
+
+    // Direction: expense, +deviation = unfavorable, −deviation = favorable.
+    const a = acc.journals.find((j) => j.journalId === 'a')!
+    const b = acc.journals.find((j) => j.journalId === 'b')!
+    expect(a.driver).toBe('timing')
+    expect(a.direction).toBe('unfavorable')
+    expect(b.driver).toBe('run_rate')
+    expect(b.direction).toBe('favorable')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GOLDEN scenario 3: edge cases (§6.3)
+// ---------------------------------------------------------------------------
+
+describe('GOLDEN — edge cases', () => {
+  it('new_unbudgeted: budget = 0, actual ≠ 0 (§6.3 missing budget)', () => {
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '630',
+          accountName: '通信費',
+          category: 'sga_expense',
+          budget: 0,
+          actual: 60000,
+          journals: [expenseJournal('only', 60000, '2025-06-10')],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '630')!
+
+    expect(acc.variance).toBe(60000)
+    expect(acc.achievementRate).toBeNull() // budget 0 → undefined rate
+    expect(acc.variancePct).toBeNull()
+    expect(acc.favorable).toBe(false) // unexpected expense
+    const byDriver = new Map(acc.drivers.map((d) => [d.driver, d]))
+    expect(byDriver.get('new_unbudgeted')!.amount).toBe(60000)
+    expect(byDriver.get('new_unbudgeted')!.journalsCount).toBe(1)
+    expect(byDriver.get('unreconciled')!.amount).toBe(0) // journal sums to actual
+    expect(acc.journals[0].driver).toBe('new_unbudgeted')
+    expect(acc.journals[0].deviation).toBe(60000) // expected 0
+    expect(acc.journals[0].contributionPct).toBeCloseTo(100, 6)
+  })
+
+  it('absence: budget > 0, actual ≈ 0, no journals (§6.3 budget but no journals)', () => {
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '650',
+          accountName: '地代家賃',
+          category: 'sga_expense',
+          budget: 200000,
+          actual: 0,
+          journals: [],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '650')!
+
+    expect(acc.variance).toBe(-200000)
+    expect(acc.favorable).toBe(true) // under-spent expense = favorable
+    expect(acc.material).toBe(true)
+    expect(acc.drivers).toHaveLength(1)
+    expect(acc.drivers[0].driver).toBe('absence')
+    expect(acc.drivers[0].amount).toBe(-200000)
+    expect(acc.journals).toEqual([])
+    expect(acc.journalAttributionConfidence).toBe('low')
+    expect(acc.achievementRate).toBe(0)
+  })
+
+  it('unreconciled: budget > 0, actual material, no journals resolved (§6.3 unreconciled)', () => {
+    // actual 30,000 is at/above the materiality floor (10,000) → NOT absence → unreconciled.
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '640',
+          accountName: '水道光熱費',
+          category: 'sga_expense',
+          budget: 100000,
+          actual: 30000,
+          journals: [],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '640')!
+
+    expect(acc.variance).toBe(-70000)
+    expect(acc.drivers[0].driver).toBe('unreconciled')
+    expect(acc.drivers[0].amount).toBe(-70000)
+    expect(acc.favorable).toBe(true) // expense under budget
+  })
+
+  it('immaterial: variance below the floor is aggregated, not exploded (§6.2)', () => {
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '620',
+          accountName: '旅費交通費',
+          category: 'sga_expense',
+          budget: 50000,
+          actual: 52000,
+          journals: [expenseJournal('t', 52000, '2025-06-10')],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '620')!
+
+    expect(acc.material).toBe(false) // |2,000| < 50,000 threshold
+    expect(acc.drivers).toHaveLength(1)
+    expect(acc.drivers[0].driver).toBe('immaterial')
+    expect(acc.drivers[0].amount).toBe(2000)
+    expect(acc.journals).toEqual([]) // not exploded to journals
+  })
+
+  it('revenue with a sales return: credit (+) and debit (−) sign correctly (§6.4 step 1)', () => {
+    // Budget 1,000,000; actual 950,000 = 1,000,000 sale − 50,000 return.
+    // The account under test is itself revenue, so it provides the materiality base
+    // (totalRevenue 950,000 → threshold 10,000; |variance| 50,000 is material).
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        {
+          accountCode: '400',
+          accountName: '売上高',
+          category: 'revenue',
+          budget: 1000000,
+          actual: 950000,
+          journals: [
+            revenueJournal('sale', 1000000, '2025-06-15', 'credit'),
+            revenueJournal('ret', 50000, '2025-06-30', 'debit'), // boundary → timing
+          ],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '400')!
+
+    expect(acc.signConvention).toBe('revenue')
+    expect(acc.variance).toBe(-50000)
+    expect(acc.favorable).toBe(false) // revenue under budget = unfavorable
+    expect(acc.reconciliation.journalSum).toBe(950000) // 1,000,000 − 50,000
+
+    // expected = 500,000. sale deviation +500,000 (run_rate); return deviation −550,000 (timing).
+    const byDriver = new Map(acc.drivers.map((d) => [d.driver, d]))
+    expect(byDriver.get('run_rate')!.amount).toBe(500000)
+    expect(byDriver.get('timing')!.amount).toBe(-550000)
+    expect(byDriver.get('unreconciled')!.amount).toBe(0)
+    const driverSum = acc.drivers.reduce((s, d) => s + d.amount, 0)
+    expect(driverSum).toBeCloseTo(acc.variance, 6)
+
+    const sale = acc.journals.find((j) => j.journalId === 'sale')!
+    const ret = acc.journals.find((j) => j.journalId === 'ret')!
+    expect(sale.signedAmount).toBe(1000000) // credit increases revenue
+    expect(ret.signedAmount).toBe(-50000) // debit reduces revenue
+    expect(sale.direction).toBe('favorable') // more revenue than expected
+    expect(ret.direction).toBe('unfavorable') // return reduces revenue
+  })
+
+  it('negative actual (a refund exceeding budgeted expense) is handled', () => {
+    // Expense budget 100,000; actual −20,000 (large rebate credit). One credit journal.
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        materialityBaseRevenue(10000000),
+        {
+          accountCode: '670',
+          accountName: '雑費',
+          category: 'sga_expense',
+          budget: 100000,
+          actual: -20000,
+          journals: [
+            {
+              journalId: 'rebate',
+              freeeJournalId: 'rebate',
+              entryDate: '2025-06-20',
+              description: 'rebate',
+              amount: 120000,
+              side: 'credit',
+            },
+          ],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '670')!
+
+    // signedAmount for expense credit = −120,000; journalSum = −120,000 = actual + unreconciled.
+    expect(acc.reconciliation.journalSum).toBe(-120000)
+    expect(acc.reconciliation.unreconciled).toBe(100000) // actual −20,000 − (−120,000)
+    expect(acc.variance).toBe(-120000) // −20,000 − 100,000
+    expect(acc.favorable).toBe(true) // expense well under budget
+    const driverSum = acc.drivers.reduce((s, d) => s + d.amount, 0)
+    expect(driverSum).toBeCloseTo(acc.variance, 6)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GOLDEN scenario 4: validation & Result contract
+// ---------------------------------------------------------------------------
+
+describe('Result contract & validation', () => {
+  it('returns failure for invalid month', () => {
+    const result = attributeVariance({
+      fiscalYear: FY,
+      month: 13,
+      actualsSource: 'monthly_balance',
+      accounts: [],
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('VALIDATION_ERROR')
+    }
+  })
+
+  it('returns failure for an account with an invalid category', () => {
+    const result = attributeVariance({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        {
+          accountCode: '600',
+          accountName: 'x',
+          category: 'invalid' as unknown as 'sga_expense',
+          budget: 0,
+          actual: 0,
+          journals: [],
+        },
+      ],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('returns failure for an unsupported expected-amount model', () => {
+    const result = attributeVariance(
+      { fiscalYear: FY, month: MO, actualsSource: 'monthly_balance', accounts: [] },
+      { expectedModel: 'M2' as unknown as 'M0' }
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('BUSINESS_LOGIC_ERROR')
+    }
+  })
+
+  it('returns success with empty accounts', () => {
+    const out = run({ fiscalYear: FY, month: MO, actualsSource: 'none', accounts: [] })
+    expect(out.accounts).toEqual([])
+    expect(out.summary.totalVariance).toBe(0)
+    expect(out.summary.favorable).toBeNull()
+    expect(out.dataQuality.budgetCoveragePct).toBe(0)
+    expect(out.dataQuality.actualsSource).toBe('none')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GOLDEN property: reconciliation identity across constructed cases
+// ---------------------------------------------------------------------------
+
+describe('reconciliation identity (§6.5): Σ drivers = variance, Σ pct = 100', () => {
+  const cases: { name: string; account: AccountAttributionInput; revenue: number }[] = [
+    {
+      name: 'outlier + run_rate, clean reconcile',
+      revenue: 10000000,
+      account: {
+        accountCode: '600',
+        accountName: '給与手当',
+        category: 'sga_expense',
+        budget: 800000,
+        actual: 940000,
+        journals: [
+          ...Array.from({ length: 24 }, (_, i) => expenseJournal(`r${i}`, 35000, '2025-06-15')),
+          expenseJournal('b', 100000, '2025-06-25'),
+        ],
+      },
+    },
+    {
+      name: 'reconciliation gap, low confidence',
+      revenue: 10000000,
+      account: {
+        accountCode: '660',
+        accountName: '広告宣伝費',
+        category: 'sga_expense',
+        budget: 200000,
+        actual: 250000,
+        journals: [
+          expenseJournal('a', 120000, '2025-06-01'),
+          expenseJournal('b', 80000, '2025-06-15'),
+        ],
+      },
+    },
+    {
+      name: 'new unbudgeted',
+      revenue: 10000000,
+      account: {
+        accountCode: '630',
+        accountName: '通信費',
+        category: 'sga_expense',
+        budget: 0,
+        actual: 60000,
+        journals: [expenseJournal('x', 60000, '2025-06-10')],
+      },
+    },
+    {
+      name: 'revenue with returns',
+      revenue: 10000000,
+      account: {
+        accountCode: '400',
+        accountName: '売上高',
+        category: 'revenue',
+        budget: 1000000,
+        actual: 950000,
+        journals: [
+          revenueJournal('s', 1000000, '2025-06-15', 'credit'),
+          revenueJournal('r', 50000, '2025-06-30', 'debit'),
+        ],
+      },
+    },
+    {
+      name: 'cost of sales',
+      revenue: 10000000,
+      account: {
+        accountCode: '500',
+        accountName: '売上原価',
+        category: 'cost_of_sales',
+        budget: 4000000,
+        actual: 4600000,
+        journals: [
+          expenseJournal('c1', 2000000, '2025-06-10'),
+          expenseJournal('c2', 2000000, '2025-06-20'),
+          expenseJournal('c3', 600000, '2025-06-30'), // boundary → timing
+        ],
+      },
+    },
+  ]
+
+  for (const c of cases) {
+    it(`${c.name}: drivers reconcile to variance`, () => {
+      // When the account under test is itself revenue, it provides the materiality base;
+      // otherwise a separate revenue base is added (distinct accountCode, no collision).
+      const accounts =
+        c.account.category === 'revenue'
+          ? [c.account]
+          : [materialityBaseRevenue(c.revenue), c.account]
+      const out = run({
+        fiscalYear: FY,
+        month: MO,
+        actualsSource: 'monthly_balance',
+        accounts,
+      })
+      const acc = out.accounts.find((a) => a.accountCode === c.account.accountCode)!
+      const driverSum = acc.drivers.reduce((s, d) => s + d.amount, 0)
+      expect(driverSum).toBeCloseTo(acc.variance, 6)
+      if (acc.variance !== 0) {
+        const pctSum = acc.drivers.reduce((s, d) => s + (d.pctOfVariance ?? 0), 0)
+        expect(pctSum).toBeCloseTo(100, 6)
+      }
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// GOLDEN: materiality threshold helper
+// ---------------------------------------------------------------------------
+
+describe('materialityThreshold (§6.2)', () => {
+  const opts = {
+    topK: 10,
+    materialityAbsoluteFloor: 10000,
+    materialityPctOfRevenue: 0.005,
+    outlierZThreshold: 2.5,
+    unreconciledTolerancePct: 0.1,
+    expectedModel: 'M0' as const,
+  }
+  it('is max(absoluteFloor, pct × revenue)', () => {
+    expect(materialityThreshold(1000000, opts)).toBe(10000) // 0.5% of 1M = 5,000 < 10,000
+    expect(materialityThreshold(10000000, opts)).toBe(50000) // 0.5% of 10M = 50,000
+    expect(materialityThreshold(5000000, opts)).toBe(25000) // 0.5% of 5M = 25,000
+  })
+})


### PR DESCRIPTION
> [!IMPORTANT]
> ## Risk class B — Compliance review required

## Auto-generated PR — task `fin-impl-01`

**Risk class:** `B`
**Title:** 予実 journal-level variance-attribution module (strengthen budget service)

### Files declared in task
- src/services/budget
- tests/unit/services/budget

### Files actually changed (7)
- docs/auto-sessions/fin-impl-01/summary.md
- src/services/budget/detailed-actual-vs-budget.ts
- src/services/budget/variance-attribution-loader.ts
- src/services/budget/variance-attribution.ts
- tests/unit/services/budget/detailed-actual-vs-budget.test.ts
- tests/unit/services/budget/variance-attribution-loader.test.ts
- tests/unit/services/budget/variance-attribution.test.ts


### Subagents declared
_(none)_

### Commit
`auto(B): 予実 journal-level variance-attribution module (strengthen budget service)`

### Required human review
- [ ] Compliance review
- [ ] Simulation evidence (if applicable)
- [ ] Architecture boundary verified
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._