### PR TITLE
[auto/C] auto(C): Add unit tests for src/components/conversion/profit-loss-table.tsx

### DIFF
--- a/docs/auto-sessions/gap-untested-module-18d3517075/summary.md
+++ b/docs/auto-sessions/gap-untested-module-18d3517075/summary.md
@@ -1,0 +1,83 @@
+# gap-untested-module-18d3517075 — unit tests for `profit-loss-table.tsx`
+
+**Target:** `src/components/conversion/profit-loss-table.tsx`
+**Test file:** `tests/components/conversion/profit-loss-table.test.tsx`
+**Risk class:** C (presentational React component)
+**Date:** 2026-07-12
+
+## What was added
+
+`ProfitLossTable` is a pure presentational component. It renders a shadcn
+`<Table>` of a `ConvertedProfitLoss`, formatting every amount with
+`new Intl.NumberFormat('ja-JP')` and optionally exposing a `showSource` column.
+There are no async collaborators, no side effects, and no props that can make
+the component throw — so "error paths / timeouts" map to graceful handling of
+extreme/empty inputs (covered in the edge-case suite), not to thrown exceptions.
+
+The suite adds **19 tests** across 5 `describe` blocks. Amount assertions use a
+`lastCellText(anchor)` helper that anchors on a unique label/code and reads the
+trailing `<td>` of the row, so assertions never collide on duplicate amounts.
+
+## Assertions by group
+
+### structure & defaults
+- `screen.getByRole('table')` is present; container `firstElementChild` has
+  `rounded-lg` and `border` classes.
+- Custom `className` (`"my-extra"`) is merged onto the container alongside the
+  base classes.
+- Default (no `showSource`): headers `コード`, `科目名`, `金額` render; `ソース`
+  is absent; `getAllByRole('columnheader')` length is **3**; a known
+  `sourceAccountCode` (`4000`) is **not** rendered.
+
+### sections & subtotals
+- All five section titles render: `売上高`, `売上原価`, `販売費及び一般管理費`,
+  `営業外収益`, `営業外費用`.
+- All six subtotal labels render: `売上高合計`, `売上総利益`, `営業利益`,
+  `経常利益`, `税引前当期純利益`, `当期純利益`.
+- Section-title cell `colspan` = `"3"` (3-column body).
+- Every line item's `code` and `name` render.
+
+### amount formatting (ja-JP) — happy path + boundaries
+- Line-item amounts are grouped with commas: `600,000`, `511,000`, `10,000`, …
+- Subtotal amounts render verbatim from the supplied numbers.
+- **Computed subtotal:** revenue subtotal = sum of revenue items
+  (`333,333 + 222,222 → 555,555`), proving the live `reduce` path, not a stored
+  value.
+- **Zero boundary:** amount `0` formats as `"0"` (and revenue subtotal of an
+  empty-sum path is `"0"`).
+- **Negative (loss) boundary:** `-1,000`, `-1,234,567`, `-50,000` — leading
+  minus preserved.
+- **Large-value boundary:** `1,000,000,000,000` and `999,999,999,999` format
+  without precision loss or overflow.
+
+### showSource column
+- `showSource` adds the `ソース` header and a **4th** columnheader cell.
+- Section-title cell `colspan` widens to `"4"`.
+- Each item's `sourceAccountCode` renders (`4000`, `4090`, `5000`, `7000`,
+  `8000`, `9000`).
+- **Fail-safe:** missing (`undefined`) and empty-string (`""`) `sourceAccountCode`
+  both degrade to `"-"`; two missing sources yield exactly two dash cells.
+
+### empty / fail-safe
+- With all five arrays empty, every section title and the `売上高合計` subtotal
+  still render; no item `code`s appear; the empty revenue list sums to `"0"`.
+- The unreachable per-section total row (text `"売上高 合計"` etc., from the
+  `renderSection(total?)` branch that is never invoked) is **never** emitted,
+  under both `showSource` states — guarding against phantom totals.
+
+## Coverage rationale
+
+- **Happy path:** structure, defaults, all sections/subtotals/items rendered.
+- **Edge cases:** empty arrays, zero, negative, and large (trillion-scale)
+  amounts; missing/empty source codes.
+- **Fail-safe:** graceful degradation to `"-"` for absent sources, `"0"` for
+  empty sums, and confirmation that the dead `total` branch produces no output.
+- **Determinism:** no network, clock, or randomness — `Intl.NumberFormat('ja-JP')`
+  is deterministic under Node ≥ 20 full ICU; dates are constructor-supplied.
+
+## Verification
+
+- `pnpm vitest run tests/components/conversion/profit-loss-table.test.tsx` →
+  **19 passed**.
+- `eslint --max-warnings=0` on the new test file → **clean** (0 warnings).
+- `tsc --noEmit` (full project, after `pnpm db:generate`) → **exit 0**.

--- a/tests/components/conversion/profit-loss-table.test.tsx
+++ b/tests/components/conversion/profit-loss-table.test.tsx
@@ -1,0 +1,286 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { ProfitLossTable } from '@/components/conversion/profit-loss-table'
+import type { ConvertedProfitLoss } from '@/types/conversion'
+
+type PLItem = ConvertedProfitLoss['revenue'][number]
+
+function makeItem(overrides: Partial<PLItem> = {}): PLItem {
+  return {
+    code: '4110',
+    name: '商品売上',
+    nameEn: 'Product Sales',
+    amount: 600_000,
+    sourceAccountCode: '4000',
+    ...overrides,
+  }
+}
+
+function makeData(overrides: Partial<ConvertedProfitLoss> = {}): ConvertedProfitLoss {
+  return {
+    periodStart: new Date('2025-01-01'),
+    periodEnd: new Date('2025-12-31'),
+    revenue: [
+      makeItem({ code: '4110', name: '商品売上', amount: 600_000, sourceAccountCode: '4000' }),
+      makeItem({ code: '4120', name: '役務売上', amount: 400_000, sourceAccountCode: '4090' }),
+    ],
+    costOfSales: [
+      makeItem({ code: '5110', name: '商品仕入', amount: 511_000, sourceAccountCode: '5000' }),
+    ],
+    sgaExpenses: [
+      makeItem({ code: '7110', name: '給与手当', amount: 200_000, sourceAccountCode: '7000' }),
+    ],
+    nonOperatingIncome: [
+      makeItem({ code: '8110', name: '受取利息', amount: 10_000, sourceAccountCode: '8000' }),
+    ],
+    nonOperatingExpenses: [
+      makeItem({ code: '9110', name: '支払利息', amount: 5_000, sourceAccountCode: '9000' }),
+    ],
+    grossProfit: 489_000,
+    operatingIncome: 289_000,
+    ordinaryIncome: 294_000,
+    incomeBeforeTax: 290_000,
+    netIncome: 150_000,
+    ...overrides,
+  }
+}
+
+// Anchors on a unique cell label/code, returns the last cell's text (the amount) in that row.
+function lastCellText(anchorText: string): string {
+  const anchor = screen.getByText(anchorText)
+  const row = anchor.closest('tr') as HTMLTableRowElement | null
+  if (!row) return ''
+  const cells = within(row).getAllByRole('cell')
+  return cells[cells.length - 1].textContent ?? ''
+}
+
+describe('conversion/profit-loss-table — structure & defaults', () => {
+  it('renders a table inside the bordered container', () => {
+    const { container } = render(<ProfitLossTable data={makeData()} />)
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(container.firstElementChild).toHaveClass('rounded-lg', 'border')
+  })
+
+  it('merges a custom className onto the container', () => {
+    const { container } = render(<ProfitLossTable data={makeData()} className="my-extra" />)
+
+    expect(container.firstElementChild).toHaveClass('rounded-lg', 'border', 'my-extra')
+  })
+
+  it('shows the 3-column header by default and omits the source column', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    expect(screen.getByText('コード')).toBeInTheDocument()
+    expect(screen.getByText('科目名')).toBeInTheDocument()
+    expect(screen.getByText('金額')).toBeInTheDocument()
+    expect(screen.queryByText('ソース')).not.toBeInTheDocument()
+    expect(screen.getAllByRole('columnheader')).toHaveLength(3)
+    // sourceAccountCode values are not rendered when showSource is off
+    expect(screen.queryByText('4000')).not.toBeInTheDocument()
+  })
+})
+
+describe('conversion/profit-loss-table — sections & subtotals', () => {
+  it('renders all five section titles', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    expect(screen.getByText('売上高')).toBeInTheDocument()
+    expect(screen.getByText('売上原価')).toBeInTheDocument()
+    expect(screen.getByText('販売費及び一般管理費')).toBeInTheDocument()
+    expect(screen.getByText('営業外収益')).toBeInTheDocument()
+    expect(screen.getByText('営業外費用')).toBeInTheDocument()
+  })
+
+  it('renders all six subtotal labels', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    expect(screen.getByText('売上高合計')).toBeInTheDocument()
+    expect(screen.getByText('売上総利益')).toBeInTheDocument()
+    expect(screen.getByText('営業利益')).toBeInTheDocument()
+    expect(screen.getByText('経常利益')).toBeInTheDocument()
+    expect(screen.getByText('税引前当期純利益')).toBeInTheDocument()
+    expect(screen.getByText('当期純利益')).toBeInTheDocument()
+  })
+
+  it('spans the section title cell across the 3-column body', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    const titleCell = screen.getByText('売上高').closest('td') as HTMLTableCellElement | null
+    expect(titleCell).toHaveAttribute('colspan', '3')
+  })
+
+  it('renders the code and name of every line item', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    for (const code of ['4110', '4120', '5110', '7110', '8110', '9110']) {
+      expect(screen.getByText(code)).toBeInTheDocument()
+    }
+    for (const name of ['商品売上', '役務売上', '商品仕入', '給与手当', '受取利息', '支払利息']) {
+      expect(screen.getByText(name)).toBeInTheDocument()
+    }
+  })
+})
+
+describe('conversion/profit-loss-table — amount formatting (ja-JP)', () => {
+  it('formats line-item amounts with ja-JP thousands grouping', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    expect(lastCellText('4110')).toBe('600,000')
+    expect(lastCellText('4120')).toBe('400,000')
+    expect(lastCellText('5110')).toBe('511,000')
+    expect(lastCellText('7110')).toBe('200,000')
+    expect(lastCellText('8110')).toBe('10,000')
+    expect(lastCellText('9110')).toBe('5,000')
+  })
+
+  it('renders subtotal amounts verbatim from the supplied data', () => {
+    render(<ProfitLossTable data={makeData()} />)
+
+    expect(lastCellText('売上高合計')).toBe('1,000,000')
+    expect(lastCellText('売上総利益')).toBe('489,000')
+    expect(lastCellText('営業利益')).toBe('289,000')
+    expect(lastCellText('経常利益')).toBe('294,000')
+    expect(lastCellText('税引前当期純利益')).toBe('290,000')
+    expect(lastCellText('当期純利益')).toBe('150,000')
+  })
+
+  it('computes the revenue subtotal as the sum of revenue line items', () => {
+    render(
+      <ProfitLossTable
+        data={makeData({
+          revenue: [
+            makeItem({ code: '4110', name: '商品売上', amount: 333_333 }),
+            makeItem({ code: '4120', name: '役務売上', amount: 222_222 }),
+          ],
+        })}
+      />
+    )
+
+    // 333,333 + 222,222 = 555,555 — a value not equal to any single item
+    expect(lastCellText('売上高合計')).toBe('555,555')
+  })
+
+  it('formats a zero amount as "0"', () => {
+    render(
+      <ProfitLossTable
+        data={makeData({
+          revenue: [makeItem({ code: '4110', name: '商品売上', amount: 0 })],
+          grossProfit: 0,
+          operatingIncome: 0,
+          ordinaryIncome: 0,
+          incomeBeforeTax: 0,
+          netIncome: 0,
+        })}
+      />
+    )
+
+    expect(lastCellText('4110')).toBe('0')
+    expect(lastCellText('売上高合計')).toBe('0')
+    expect(lastCellText('売上総利益')).toBe('0')
+    expect(lastCellText('当期純利益')).toBe('0')
+  })
+
+  it('formats negative amounts (losses) with a leading minus sign', () => {
+    render(
+      <ProfitLossTable
+        data={makeData({ grossProfit: -1_000, operatingIncome: -1_234_567, netIncome: -50_000 })}
+      />
+    )
+
+    expect(lastCellText('売上総利益')).toBe('-1,000')
+    expect(lastCellText('営業利益')).toBe('-1,234,567')
+    expect(lastCellText('当期純利益')).toBe('-50,000')
+  })
+
+  it('formats large amounts without losing precision', () => {
+    render(
+      <ProfitLossTable
+        data={makeData({
+          revenue: [makeItem({ code: '4110', name: '商品売上', amount: 1_000_000_000_000 })],
+          netIncome: 999_999_999_999,
+        })}
+      />
+    )
+
+    expect(lastCellText('4110')).toBe('1,000,000,000,000')
+    expect(lastCellText('売上高合計')).toBe('1,000,000,000,000')
+    expect(lastCellText('当期純利益')).toBe('999,999,999,999')
+  })
+})
+
+describe('conversion/profit-loss-table — showSource column', () => {
+  it('adds the source column header and a fourth header cell', () => {
+    render(<ProfitLossTable data={makeData()} showSource />)
+
+    expect(screen.getByText('ソース')).toBeInTheDocument()
+    expect(screen.getAllByRole('columnheader')).toHaveLength(4)
+  })
+
+  it('widens the section title cells to span 4 columns', () => {
+    render(<ProfitLossTable data={makeData()} showSource />)
+
+    const titleCell = screen.getByText('売上高').closest('td') as HTMLTableCellElement | null
+    expect(titleCell).toHaveAttribute('colspan', '4')
+  })
+
+  it('renders the sourceAccountCode for every line item', () => {
+    render(<ProfitLossTable data={makeData()} showSource />)
+
+    for (const source of ['4000', '4090', '5000', '7000', '8000', '9000']) {
+      expect(screen.getByText(source)).toBeInTheDocument()
+    }
+  })
+
+  it('falls back to a dash when sourceAccountCode is missing or empty', () => {
+    render(
+      <ProfitLossTable
+        data={makeData({
+          revenue: [
+            makeItem({ code: '4110', name: '商品売上', amount: 100, sourceAccountCode: undefined }),
+            makeItem({ code: '4120', name: '役務売上', amount: 100, sourceAccountCode: '' }),
+          ],
+        })}
+        showSource
+      />
+    )
+
+    expect(screen.getAllByText('-')).toHaveLength(2)
+  })
+})
+
+describe('conversion/profit-loss-table — empty / fail-safe', () => {
+  it('renders all sections and subtotals even when every section is empty', () => {
+    render(
+      <ProfitLossTable
+        data={makeData({
+          revenue: [],
+          costOfSales: [],
+          sgaExpenses: [],
+          nonOperatingIncome: [],
+          nonOperatingExpenses: [],
+        })}
+      />
+    )
+
+    expect(screen.getByText('売上高')).toBeInTheDocument()
+    expect(screen.getByText('営業外費用')).toBeInTheDocument()
+    expect(screen.getByText('売上高合計')).toBeInTheDocument()
+    // no line-item codes are present
+    expect(screen.queryByText('4110')).not.toBeInTheDocument()
+    // revenue subtotal sums an empty list to 0
+    expect(lastCellText('売上高合計')).toBe('0')
+  })
+
+  it('never emits the unreachable per-section total row', () => {
+    // renderSection is never called with a `total`, so the "X 合計" rows are dead
+    // code and must never appear regardless of input.
+    render(<ProfitLossTable data={makeData()} showSource />)
+
+    expect(screen.queryByText('売上高 合計')).not.toBeInTheDocument()
+    expect(screen.queryByText('売上原価 合計')).not.toBeInTheDocument()
+    expect(screen.queryByText('販売費及び一般管理費 合計')).not.toBeInTheDocument()
+    expect(screen.queryByText('営業外収益 合計')).not.toBeInTheDocument()
+    expect(screen.queryByText('営業外費用 合計')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> Risk class C — standard PR review.

## Auto-generated PR — task `gap-untested-module-18d3517075`

**Risk class:** `C`
**Title:** Add unit tests for src/components/conversion/profit-loss-table.tsx

### Files declared in task
- src/components/conversion/profit-loss-table.tsx

### Files actually changed (2)
- docs/auto-sessions/gap-untested-module-18d3517075/summary.md
- tests/components/conversion/profit-loss-table.test.tsx


### Subagents declared
_(none)_

### Commit
`auto(C): Add unit tests for src/components/conversion/profit-loss-table.tsx`

### Required human review
- [ ] Compliance review
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._