### PR TITLE
ci: halve unit-test shards 64→32 (relieve Actions congestion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
   # exposes a single 'Unit Tests' status check that branch protection can
   # depend on regardless of shard count.
   unit-tests-shard:
-    name: Unit Tests Shard (${{ matrix.shard }}/64)
+    name: Unit Tests Shard (${{ matrix.shard }}/32)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -77,11 +77,7 @@ jobs:
           [1, 2, 3, 4, 5, 6, 7, 8,
            9, 10, 11, 12, 13, 14, 15, 16,
            17, 18, 19, 20, 21, 22, 23, 24,
-           25, 26, 27, 28, 29, 30, 31, 32,
-           33, 34, 35, 36, 37, 38, 39, 40,
-           41, 42, 43, 44, 45, 46, 47, 48,
-           49, 50, 51, 52, 53, 54, 55, 56,
-           57, 58, 59, 60, 61, 62, 63, 64]
+           25, 26, 27, 28, 29, 30, 31, 32]
     env:
       DATABASE_URL: 'file:./test.db'
       JWT_SECRET: 'test-jwt-secret'
@@ -112,7 +108,7 @@ jobs:
       - name: Generate Prisma Client
         run: pnpm db:generate
 
-      - name: Run Unit Tests Shard ${{ matrix.shard }}/64
+      - name: Run Unit Tests Shard ${{ matrix.shard }}/32
         # `--coverage` is intentionally dropped from the sharded run: coverage
         # merging across shards is non-trivial and the per-shard threshold
         # would always fail. Coverage gating moves to a follow-up Phase 1
@@ -126,7 +122,7 @@ jobs:
         #   from earlier renders).
         # The two files whose per-file memory consumption alone exceeded the
         # heap are quarantined in vitest.config.ts (see exclude list).
-        run: pnpm test -- --shard=${{ matrix.shard }}/64
+        run: pnpm test -- --shard=${{ matrix.shard }}/32
 
   unit-tests:
     name: Unit Tests


### PR DESCRIPTION
20 open PRs × 64 shards gridlocked GitHub Actions (0 mergeable). leak-01 is fixed and heap is 6144MB, so 32 shards (~2x tests each) should stay in budget while halving per-PR job count. This PR's own CI runs at 32 shards — if green, it unblocks the queue; if OOM, revert.