### PR TITLE
[auto/C] auto(C): Add unit tests for src/components/conversion/status-badge.tsx

### DIFF
--- a/docs/auto-sessions/gap-untested-module-d5f557d129/summary.md
+++ b/docs/auto-sessions/gap-untested-module-d5f557d129/summary.md
@@ -1,0 +1,87 @@
+# gap-untested-module-d5f557d129 — Unit tests for `status-badge.tsx`
+
+**Target:** `src/components/conversion/status-badge.tsx`
+**Test file:** `tests/components/conversion/status-badge.test.tsx` (new)
+**Result:** 24 tests, all passing. ESLint `--max-warnings=0` clean. `tsc` reports **0** errors for the new file.
+
+---
+
+## What the module does
+
+`StatusBadge` is a pure presentational component. It maps each `ConversionStatus`
+(`draft | mapping | validating | converting | reviewing | completed | error`) to a
+Japanese label + a `Badge` variant + (optionally) a status-specific color class, and
+applies one of three size paddings (`sm | md | lg`, default `md`). The public surface
+is a single named export, `StatusBadge`.
+
+## Coverage rationale
+
+The module's logic is a closed map over a finite union plus three size branches and a
+`cn()` (tailwind-merge) class merge. Coverage therefore means:
+
+1. **Completeness** — exercise every member of the `ConversionStatus` union (no status
+   left unrendered).
+2. **Each size branch** — `sm`/`md`/`lg`, plus the default-`md` branch when `size` is omitted.
+3. **Class merging** — the `className` prop is appended and the base badge classes survive.
+4. **The one non-trivial behavior** — tailwind-merge: a status-specific `bg-*-100` color
+   **replaces** (not layers with) the `secondary` variant's `bg-secondary` base.
+
+## Assertions added (24)
+
+### `StatusBadge — label & variant for every ConversionStatus` (8)
+- One per status (7): the correct Japanese label is present and the expected class is
+  present —
+  - `draft` → `下書き`, `text-foreground` (outline variant survives)
+  - `mapping` → `マッピング中`, `bg-blue-100`
+  - `validating` → `検証中`, `bg-yellow-100`
+  - `converting` → `変換中`, `bg-primary` (default variant survives)
+  - `reviewing` → `レビュー中`, `bg-purple-100`
+  - `completed` → `完了`, `bg-green-100`
+  - `error` → `エラー`, `bg-destructive` (destructive variant survives)
+- 4 cases: the colored statuses (`mapping`/`validating`/`reviewing`/`completed`) assert
+  the status color is present **and** `bg-secondary` is **absent** — proving the override
+  wins rather than double-painting the background.
+- 1 case: exactly one badge / one label per render (no duplication).
+
+### `StatusBadge — size variants` (7)
+- `sm` → `text-xs`; `md` → `text-sm`; `lg` → `text-base`.
+- `sm` → `px-1.5 py-0`; `md` → `px-2 py-0.5`; `lg` → `px-3 py-1`.
+- Default `md` when `size` is omitted (`text-sm` + `px-2`).
+
+### `StatusBadge — className merging` (3)
+- Custom `className` is appended.
+- Custom `className` coexists with base classes (`bg-primary`, `rounded-full`).
+- Empty-string `className` does not break rendering.
+
+### `StatusBadge — structure` (2)
+- Badge carries `rounded-full`.
+- Label text appears exactly once.
+
+## Fail-safe note (honest)
+
+The task brief asked for a fail-safe assertion ("fault modes degrade to a safe state").
+This component has **no runtime fail-safe path**: `status` is a closed TS union, and
+`STATUS_CONFIG[status]` dereferences `config.variant`/`config.label` immediately, so an
+out-of-union value would throw rather than degrade. Because the type system makes such
+input unreachable from well-typed callers, fabricating a "degrades to safe state" test
+would be fake green. Instead the fail-safe coverage is delivered as **completeness** —
+every member of the union renders without throwing — which is the real guarantee the
+component provides. This is documented here rather than asserted falsely.
+
+## Determinism
+
+No network, clock, or randomness. Pure render + className string assertions under jsdom.
+
+## Verification
+
+```
+pnpm exec vitest run tests/components/conversion/status-badge.test.tsx
+# Test Files  1 passed (1)
+#      Tests  24 passed (24)
+
+pnpm exec eslint tests/components/conversion/status-badge.test.tsx --max-warnings=0   # exit 0
+pnpm exec tsc --noEmit                                                                 # 0 errors for status-badge.*
+```
+
+Pre-existing phantom `TS7006` errors elsewhere in the repo (unrelated test files) are
+unchanged by this task.

--- a/tests/components/conversion/status-badge.test.tsx
+++ b/tests/components/conversion/status-badge.test.tsx
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusBadge } from '@/components/conversion/status-badge'
+import type { ConversionStatus } from '@/types/conversion'
+
+function badgeFor(text: string): HTMLElement {
+  return screen.getByText(text)
+}
+
+// For each status the single most-reliable class present in the rendered badge.
+// Secondary-variant statuses carry a status-specific bg-*-100 color that, via
+// tailwind-merge, REPLACES (not layers with) the bg-secondary base — so for those
+// the status color is the observable marker, while for the plain-variant statuses
+// the variant's own class survives.
+const STATUS_CASES: ReadonlyArray<{
+  status: ConversionStatus
+  label: string
+  presentClass: string
+  overriddenBase?: string
+}> = [
+  { status: 'draft', label: '下書き', presentClass: 'text-foreground' },
+  {
+    status: 'mapping',
+    label: 'マッピング中',
+    presentClass: 'bg-blue-100',
+    overriddenBase: 'bg-secondary',
+  },
+  {
+    status: 'validating',
+    label: '検証中',
+    presentClass: 'bg-yellow-100',
+    overriddenBase: 'bg-secondary',
+  },
+  { status: 'converting', label: '変換中', presentClass: 'bg-primary' },
+  {
+    status: 'reviewing',
+    label: 'レビュー中',
+    presentClass: 'bg-purple-100',
+    overriddenBase: 'bg-secondary',
+  },
+  {
+    status: 'completed',
+    label: '完了',
+    presentClass: 'bg-green-100',
+    overriddenBase: 'bg-secondary',
+  },
+  { status: 'error', label: 'エラー', presentClass: 'bg-destructive' },
+]
+
+describe('StatusBadge — label & variant for every ConversionStatus', () => {
+  it.each(STATUS_CASES)(
+    'status "$status" renders label "$label" and applies "$presentClass"',
+    ({ status, label, presentClass }) => {
+      render(<StatusBadge status={status} />)
+      const badge = badgeFor(label)
+      expect(badge).toBeInTheDocument()
+      expect(badge.className).toContain(presentClass)
+    }
+  )
+
+  it.each(STATUS_CASES.filter((c) => c.overriddenBase))(
+    'status "$status" status color ($presentClass) overrides the $overriddenBase base (no double-bg)',
+    ({ status, label, presentClass, overriddenBase }) => {
+      render(<StatusBadge status={status} />)
+      const className = badgeFor(label).className
+      expect(className).toContain(presentClass)
+      expect(className).not.toContain(overriddenBase as string)
+    }
+  )
+
+  it('renders exactly one badge per render', () => {
+    const { container } = render(<StatusBadge status="completed" />)
+    expect(container.querySelectorAll('div').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('完了')).toHaveLength(1)
+  })
+})
+
+describe('StatusBadge — size variants', () => {
+  it.each([
+    { size: 'sm', cls: 'text-xs' },
+    { size: 'md', cls: 'text-sm' },
+    { size: 'lg', cls: 'text-base' },
+  ] as const)('applies $size size classes ($cls)', ({ size, cls }) => {
+    render(<StatusBadge status="draft" size={size} />)
+    expect(badgeFor('下書き').className).toContain(cls)
+  })
+
+  it.each([
+    { size: 'sm', cls: 'px-1.5 py-0' },
+    { size: 'md', cls: 'px-2 py-0.5' },
+    { size: 'lg', cls: 'px-3 py-1' },
+  ] as const)('applies $size padding classes ($cls)', ({ size, cls }) => {
+    render(<StatusBadge status="draft" size={size} />)
+    expect(badgeFor('下書き').className).toContain(cls)
+  })
+
+  it('defaults to md size when size is omitted', () => {
+    render(<StatusBadge status="draft" />)
+    const className = badgeFor('下書き').className
+    expect(className).toContain('text-sm')
+    expect(className).toContain('px-2')
+  })
+})
+
+describe('StatusBadge — className merging', () => {
+  it('appends a custom className onto the badge', () => {
+    render(<StatusBadge status="error" className="my-custom-class" />)
+    expect(badgeFor('エラー').className).toContain('my-custom-class')
+  })
+
+  it('keeps the base badge classes alongside a custom className', () => {
+    render(<StatusBadge status="converting" className="my-custom-class" />)
+    const className = badgeFor('変換中').className
+    expect(className).toContain('my-custom-class')
+    expect(className).toContain('bg-primary')
+    expect(className).toContain('rounded-full')
+  })
+
+  it('renders an empty-string className without affecting the badge', () => {
+    render(<StatusBadge status="draft" className="" />)
+    expect(badgeFor('下書き')).toBeInTheDocument()
+  })
+})
+
+describe('StatusBadge — structure', () => {
+  it('renders a rounded-full badge element', () => {
+    render(<StatusBadge status="mapping" />)
+    expect(badgeFor('マッピング中').className).toContain('rounded-full')
+  })
+
+  it('never renders the label text more than once for a single status', () => {
+    render(<StatusBadge status="validating" />)
+    expect(screen.getAllByText('検証中')).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> Risk class C — standard PR review.

## Auto-generated PR — task `gap-untested-module-d5f557d129`

**Risk class:** `C`
**Title:** Add unit tests for src/components/conversion/status-badge.tsx

### Files declared in task
- src/components/conversion/status-badge.tsx

### Files actually changed (2)
- docs/auto-sessions/gap-untested-module-d5f557d129/summary.md
- tests/components/conversion/status-badge.test.tsx


### Subagents declared
_(none)_

### Commit
`auto(C): Add unit tests for src/components/conversion/status-badge.tsx`

### Required human review
- [ ] Compliance review
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._