### PR TITLE
[auto/C] auto(C): Deepen error/edge-case tests in analytics + budget services

### DIFF
--- a/docs/auto-sessions/edge-01/summary.md
+++ b/docs/auto-sessions/edge-01/summary.md
@@ -1,0 +1,54 @@
+# EDGE-01 — Deepen error/edge-case tests in analytics + budget services
+
+## Scope
+Added edge-case tests for already-tested, non-Class-A modules under
+`src/services/analytics/**` and `src/services/budget/**`. No source code was
+modified; no Class-A path touched. All new helpers already return `Result<T,E>`;
+inputs validated with Zod `safeParse` (the new tests exercise the failure paths).
+
+## What was done
+Six **new**, additive `-edge.test.ts` files (created rather than editing existing
+files, to avoid inheriting pre-existing lint warnings in touched files — the
+autopm gate lints changed files with `--max-warnings=0`):
+
+| File | Module deepened | Branches/lines closed |
+|------|-----------------|----------------------|
+| `tests/unit/services/budget/variance-attribution-edge.test.ts` | `variance-attribution.ts` | `isPeriodBoundary` malformed (<3 parts) & non-numeric dates (L197/201); journal `direction: 'neutral'` when deviation === 0 (L526); `freeeJournalId ?? null` right-branch (L537); sga-only input → no `category_mapping` warning (L672); `actualsSource: 'mock'` → `actuals_are_synthetic` warning (L678/679) |
+| `tests/unit/services/analytics/managerial-accounting-edge.test.ts` | `analytics/managerial-accounting.ts` | `safeRatio` overflow → null (L262); `classifyCostBehavior` invalid `overrides` value (L321); `calculateContributionMargin` non-finite/missing input (L372); `analyzeCVP` undefined break-even + supplied volume → null margin-of-safety (L476/480/481) |
+| `tests/unit/services/budget/managerial-accounting-edge.test.ts` | `budget/managerial-accounting.ts` | `buildVarianceBridge` per-stage missing detection — revenue / cost-of-sales / SGA missing one at a time (lines 133–135 + the "stage present" branch of each guard; previously only operating-income-missing was tested) |
+| `tests/unit/services/budget/detailed-actual-vs-budget-edge.test.ts` | `detailed-actual-vs-budget.ts` | `getRevenueStatus` budget 0 & actual < 0 → `'bad'` (L229); `getExpenseStatus` budget 0 & actual === 0 → `'good'` (L237); positive-actual zero-budget → `'good'` arm |
+| `tests/unit/services/budget/budget-import-edge.test.ts` | `budget-import.ts` | `parseBudgetCsv` non-month header column skipped (L40); short data row (<2 cells) skipped (L48); `validateBudgetCsv` short data row → row error (L202/203/204) |
+| `tests/unit/services/budget/variance-attribution-loader-edge.test.ts` | `variance-attribution-loader.ts` | `inferCategoryFromType` income/cogs/expense hits + null `categoryType` `?? ''` (L112–115); AccountItem code fallback chain shortcutNum→shortcut→`String(freeeId)` (L161); costOfSales resolver loop (L142); `pushJournal` second-journal-to-same-account `existing` branch (L258); `prepareAttributionInput` costOfSales actuals (L348) + null-departmentId budget excluded by dept scope (L299); `computeVarianceAttribution` non-integer fiscalYear (L395, pre-DB return) |
+
+**35 new tests, all real assertions** (no `toBeDefined()` cop-outs; hand-computed
+golden values for the CVP/overflow/boundary cases). No `any`, `@ts-ignore`,
+`.skip`, or lint-disable.
+
+## Dead branches intentionally NOT covered (no faking)
+- `variance-attribution.ts` L543/563/570 (`variance !== 0 ? … : null` in the
+  material+has-journals path): `variance === 0` is unreachable there because
+  `material = |variance| ≥ threshold` already forced a variance ≠ 0.
+- `variance-attribution.ts` L564 (`driverCounts.get(driver) ?? 0`): the driver
+  key is always populated by the preceding roll-up loop, so the `?? 0` fallback
+  is unreachable.
+- `analytics/managerial-accounting.ts` L266 (`toAppError` `details ? … : undefined`):
+  the only caller (`fromZodError`) always passes `details`, so the no-details
+  branch is dead given the current module.
+
+These are flagged here rather than papered over with contrived calls.
+
+## Verification
+- `node scripts/autopm_verify.mjs --changed-only` → **exit 0**
+  (typecheck 0 errors, eslint 0 warnings on all 6 files, vitest 35/35).
+- Full `tests/unit/services/{analytics,budget}/` suite: **20 files / 407 tests
+  pass** (was 14/372; +6 files, +35 tests) — confirms no mock cross-contamination.
+
+## Out of scope
+- `src/services/budget/sample-pl.ts` is untested but is a sample-data generator;
+  EDGE-01 deepens *already-tested* modules, so it was left for the separate
+  gap-untested-module auto-task.
+- `analytics/kpi.ts`, `budget/budget-service.ts` were already at 100% line/branch
+  coverage — nothing to deepen.
+- `financial-kpi.ts` FIN-IMPL-04 `calc*` validation-failure paths are uncovered
+  but repetitive (`if (!ok.success) return ok` × ~30); a dedicated 58-test golden
+  file already exists. Left untouched to avoid low-value duplication.

--- a/tests/unit/services/analytics/managerial-accounting-edge.test.ts
+++ b/tests/unit/services/analytics/managerial-accounting-edge.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import {
+  classifyCostBehavior,
+  calculateContributionMargin,
+  analyzeCVP,
+} from '@/services/analytics/managerial-accounting'
+import { ERROR_CODES } from '@/types/result'
+
+/**
+ * EDGE-01 — error / edge-case deepening for the analytics managerial-accounting
+ * pure core (FIN-IMPL-03).
+ *
+ * Covers branches left uncovered by the golden suite (managerial-accounting.test.ts):
+ *   - safeRatio overflow → null (a finite numerator/denominator that divides to ±Infinity),
+ *   - classifyCostBehavior validation failure on an invalid `overrides` value,
+ *   - calculateContributionMargin validation failure on non-finite input,
+ *   - analyzeCVP with an undefined break-even (CM/unit ≤ 0) AND a supplied volume →
+ *     margin-of-safety fields are null rather than computed.
+ */
+
+function unwrap<T>(r: { success: true; data: T } | { success: false; error: unknown }): T {
+  if (!r.success) throw new Error(`expected success, got error: ${JSON.stringify(r.error)}`)
+  return r.data
+}
+
+describe('safeRatio — overflow to null (boundary)', () => {
+  it('returns a null contribution-margin ratio when CM overflows to Infinity', () => {
+    // revenue 1e308, variableCosts −1e308 are both finite (≤ Number.MAX_VALUE),
+    // but revenue − variableCosts = 2e308 overflows to Infinity. safeRatio then
+    // sees a non-finite quotient and returns null (distinguishing "undefined"
+    // from a real 0%).
+    const out = unwrap(
+      calculateContributionMargin({ revenue: 1e308, variableCosts: -1e308, fixedCosts: 0 })
+    )
+    expect(out.contributionMargin).toBe(Infinity)
+    expect(out.contributionMarginRatio).toBeNull()
+  })
+})
+
+describe('classifyCostBehavior — invalid overrides', () => {
+  it('returns VALIDATION_ERROR when an override value is not variable|fixed', () => {
+    const r = classifyCostBehavior(
+      [{ accountCode: '5110', accountName: '売上原価', amount: 1000 }],
+      { overrides: { '5110': 'semi-variable' as unknown as 'variable' | 'fixed' } }
+    )
+    expect(r.success).toBe(false)
+    if (!r.success) expect(r.error.code).toBe(ERROR_CODES.VALIDATION_ERROR)
+  })
+
+  it('returns VALIDATION_ERROR when overrides is not a record', () => {
+    const r = classifyCostBehavior(
+      [{ accountCode: '5110', accountName: '売上原価', amount: 1000 }],
+      { overrides: 'not-a-record' as unknown as Record<string, 'variable' | 'fixed'> }
+    )
+    expect(r.success).toBe(false)
+    if (!r.success) expect(r.error.code).toBe(ERROR_CODES.VALIDATION_ERROR)
+  })
+})
+
+describe('calculateContributionMargin — invalid input', () => {
+  it('returns VALIDATION_ERROR on a non-finite revenue', () => {
+    const r = calculateContributionMargin({ revenue: NaN, variableCosts: 0, fixedCosts: 0 })
+    expect(r.success).toBe(false)
+    if (!r.success) expect(r.error.code).toBe(ERROR_CODES.VALIDATION_ERROR)
+  })
+
+  it('returns VALIDATION_ERROR on a missing field', () => {
+    const r = calculateContributionMargin({ revenue: 1000 } as unknown as {
+      revenue: number
+      variableCosts: number
+      fixedCosts: number
+    })
+    expect(r.success).toBe(false)
+    if (!r.success) expect(r.error.code).toBe(ERROR_CODES.VALIDATION_ERROR)
+  })
+})
+
+describe('analyzeCVP — undefined break-even with a supplied volume', () => {
+  it('nulls margin-of-safety when CM/unit is negative but a volume is given', () => {
+    // price 1,000/unit, varCost 1,500/unit → CM/unit −500 (≤ 0, no finite break-even).
+    // volume 100 supplied → actualSales / operatingIncome still computed, but MoS
+    // is undefined (no break-even to measure safety against) → null.
+    const out = unwrap(
+      analyzeCVP({
+        sellingPricePerUnit: 1000,
+        variableCostPerUnit: 1500,
+        fixedCosts: 4000,
+        volume: 100,
+      })
+    )
+    expect(out.defined).toBe(false)
+    expect(out.breakEvenVolume).toBeNull()
+    expect(out.breakEvenSales).toBeNull()
+    expect(out.actualSales).toBe(100000) // 100 × 1,000
+    expect(out.operatingIncome).toBe(-54000) // −500 × 100 − 4,000
+    expect(out.marginOfSafetyAmount).toBeNull()
+    expect(out.marginOfSafetyRatio).toBeNull()
+    // DOL is still computable (operating income ≠ 0): totalCM / OI = −50,000 / −54,000.
+    expect(out.degreeOfOperatingLeverage).toBeCloseTo((-500 * 100) / -54000, 6)
+  })
+})

--- a/tests/unit/services/budget/budget-import-edge.test.ts
+++ b/tests/unit/services/budget/budget-import-edge.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { parseBudgetCsv, validateBudgetCsv } from '@/services/budget/budget-import'
+
+/**
+ * EDGE-01 — error / edge-case deepening for budget CSV parsing/validation.
+ *
+ * Covers branches left uncovered by budget-import.test.ts:
+ *   - parseBudgetCsv: a header column at index ≥2 that is not a month (no digit),
+ *     so the `if (monthMatch)` false branch is taken and the column is skipped.
+ *   - parseBudgetCsv: a data row with fewer than 2 cells (`if (row.length < 2) continue`).
+ *   - validateBudgetCsv: a data row with fewer than 2 cells, producing the
+ *     "コードと名称が必要です" row error and a continue.
+ */
+
+vi.mock('@/lib/utils', () => ({
+  parseCsv: vi.fn((content: string) => {
+    const lines = content.split('\n').filter((l) => l.trim())
+    return lines.map((line) => line.split(','))
+  }),
+}))
+
+describe('parseBudgetCsv — non-month header columns are ignored', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips a 備考 (notes) column that contains no digit, keeping only real month columns', () => {
+    // Header: code, name, 1月, 備考, 2月. The 備考 column matches no `(\d+)月?` →
+    // skipped, so only two month columns are detected. The data row omits the
+    // notes column (sparse header), so its 3rd/4th cells align to 1月/2月.
+    const csv = `勘定科目コード,勘定科目名,1月,備考,2月
+400,売上高,1000000,2000000`
+
+    const result = parseBudgetCsv(csv)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].accountCode).toBe('400')
+    // Two month columns detected (1月 and 2月); 備考 was not treated as a month.
+    expect(result[0].months).toEqual([1000000, 2000000])
+    expect(result[0].months).toHaveLength(2)
+  })
+})
+
+describe('parseBudgetCsv — short data rows are skipped', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('skips a data row that has fewer than 2 cells', () => {
+    // Row 2 ("400") has only one cell → length 1 < 2 → skipped.
+    const csv = `勘定科目コード,勘定科目名,1月
+400
+500,売上原価,1000000`
+
+    const result = parseBudgetCsv(csv)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].accountCode).toBe('500')
+    expect(result[0].months).toEqual([1000000])
+  })
+})
+
+describe('validateBudgetCsv — short data rows produce a row error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports 勘定科目コードと名称が必要です for a single-cell data row', () => {
+    const csv = `勘定科目コード,勘定科目名,1月
+400
+500,売上原価,1000000`
+
+    const result = validateBudgetCsv(csv)
+
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('2行目'))).toBe(true)
+    expect(result.errors.some((e) => e.includes('勘定科目コードと名称が必要です'))).toBe(true)
+  })
+
+  it('still validates the well-formed rows alongside the short row', () => {
+    const csv = `勘定科目コード,勘定科目名,1月
+400
+500,売上原価,notanumber`
+
+    const result = validateBudgetCsv(csv)
+
+    // Short row (2行目) + invalid number in row 3.
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.includes('2行目: 勘定科目コードと名称が必要です'))).toBe(
+      true
+    )
+    expect(result.errors.some((e) => e.includes('3行目') && e.includes('数値が無効'))).toBe(true)
+  })
+})

--- a/tests/unit/services/budget/detailed-actual-vs-budget-edge.test.ts
+++ b/tests/unit/services/budget/detailed-actual-vs-budget-edge.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { calculateDetailedActualVsBudget } from '@/services/budget/detailed-actual-vs-budget'
+import { getBudgetsByMonth } from '@/services/budget/budget-service'
+import type { ProfitLoss } from '@/types'
+
+/**
+ * EDGE-01 — error / edge-case deepening for detailed-actual-vs-budget.
+ *
+ * The existing suite asserts `toBeDefined()` for the zero-budget rate path but
+ * never exercises the two `budget === 0` status branches:
+ *   - getRevenueStatus: budget 0, actual < 0 → 'bad' (a revenue account with no
+ *     budget that is actually negative — e.g. net returns exceeding sales).
+ *   - getExpenseStatus: budget 0, actual === 0 → 'good' (an expense account with
+ *     no budget and no actual spend).
+ * Both are reached through the public calculateDetailedActualVsBudget with an
+ * empty budget set, so every stage budget is 0.
+ */
+
+vi.mock('@/services/budget/budget-service', () => ({
+  getBudgetsByMonth: vi.fn(),
+}))
+
+function makePL(overrides: Partial<ProfitLoss> = {}): ProfitLoss {
+  return {
+    fiscalYear: 2024,
+    month: 12,
+    revenue: [],
+    costOfSales: [],
+    grossProfit: 0,
+    grossProfitMargin: 0,
+    sgaExpenses: [],
+    operatingIncome: 0,
+    operatingMargin: 0,
+    nonOperatingIncome: [],
+    nonOperatingExpenses: [],
+    ordinaryIncome: 0,
+    extraordinaryIncome: [],
+    extraordinaryLoss: [],
+    incomeBeforeTax: 0,
+    incomeTax: 0,
+    netIncome: 0,
+    depreciation: 0,
+    ...overrides,
+  }
+}
+
+describe('DetailedActualVsBudgetService — zero-budget status boundaries', () => {
+  const companyId = 'company-1'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('rates a negative actual against a zero revenue budget as bad', async () => {
+    // No budgets → every stage budget is 0. Revenue actual −500,000 (returns > sales).
+    vi.mocked(getBudgetsByMonth).mockResolvedValue([])
+    const pl = makePL({
+      revenue: [{ code: '400', name: '売上高', amount: -500000 }],
+      grossProfit: -500000,
+      operatingIncome: -500000,
+      netIncome: -500000,
+    })
+
+    const result = await calculateDetailedActualVsBudget(companyId, 2024, 12, pl)
+
+    const revenueStage = result.stageLevel.find((s) => s.stage === '売上高')!
+    expect(revenueStage.budget).toBe(0)
+    expect(revenueStage.actual).toBe(-500000)
+    expect(revenueStage.status).toBe('bad')
+    // Account-level mirrors the stage-level status for the same inputs.
+    expect(result.accountLevel.find((a) => a.code === '400')!.status).toBe('bad')
+  })
+
+  it('rates a zero actual against a zero expense budget as good', async () => {
+    // No budgets → cost-of-sales budget 0; empty costOfSales → actual 0.
+    vi.mocked(getBudgetsByMonth).mockResolvedValue([])
+    const pl = makePL({
+      revenue: [{ code: '400', name: '売上高', amount: 1000000 }],
+      costOfSales: [],
+      grossProfit: 1000000,
+      operatingIncome: 1000000,
+      netIncome: 700000,
+    })
+
+    const result = await calculateDetailedActualVsBudget(companyId, 2024, 12, pl)
+
+    const costStage = result.stageLevel.find((s) => s.stage === '売上原価')!
+    expect(costStage.budget).toBe(0)
+    expect(costStage.actual).toBe(0)
+    expect(costStage.status).toBe('good')
+  })
+
+  it('rates a positive actual against a zero revenue budget as good (non-negative path)', async () => {
+    // Covers the `actual >= 0 → good` arm of getRevenueStatus when budget is 0.
+    vi.mocked(getBudgetsByMonth).mockResolvedValue([])
+    const pl = makePL({
+      revenue: [{ code: '400', name: '売上高', amount: 300000 }],
+      grossProfit: 300000,
+      operatingIncome: 300000,
+      netIncome: 210000,
+    })
+
+    const result = await calculateDetailedActualVsBudget(companyId, 2024, 12, pl)
+
+    const revenueStage = result.stageLevel.find((s) => s.stage === '売上高')!
+    expect(revenueStage.budget).toBe(0)
+    expect(revenueStage.actual).toBe(300000)
+    expect(revenueStage.status).toBe('good')
+  })
+})

--- a/tests/unit/services/budget/managerial-accounting-edge.test.ts
+++ b/tests/unit/services/budget/managerial-accounting-edge.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { buildVarianceBridge } from '@/services/budget/managerial-accounting'
+import type { StageLevelComparison } from '@/services/budget/detailed-actual-vs-budget'
+
+/**
+ * EDGE-01 — error / edge-case deepening for the budget managerial-accounting
+ * variance-bridge builder.
+ *
+ * The existing suite only exercises the "営業利益 (operating income) stage missing"
+ * case. The missing-stage error path has four independent `if (!stage)` branches
+ * (one per required stage); each pushes a different stage name. To cover all four
+ * push statements (lines 133–136) and the "stage present" branch of each guard,
+ * we remove each of the other three stages one at a time.
+ */
+
+function stage(name: string, variance = 0): StageLevelComparison {
+  return { stage: name, budget: 0, actual: 0, variance, rate: 0, status: 'good', favorable: null }
+}
+
+const ALL_STAGES: StageLevelComparison[] = [
+  stage('売上高'),
+  stage('売上原価'),
+  stage('販売管理費'),
+  stage('営業利益'),
+]
+
+function stagesWithout(name: string): StageLevelComparison[] {
+  return ALL_STAGES.filter((s) => s.stage !== name)
+}
+
+function missingDetails(stages: StageLevelComparison[]): unknown {
+  const r = buildVarianceBridge({ stages })
+  if (r.success) throw new Error('expected failure')
+  return r.error.details
+}
+
+describe('buildVarianceBridge — per-stage missing detection', () => {
+  it('fails and names 売上高 when the revenue stage is missing', () => {
+    const details = missingDetails(stagesWithout('売上高'))
+    expect(JSON.stringify(details)).toContain('売上高')
+    expect(JSON.stringify(details)).not.toContain('売上原価')
+  })
+
+  it('fails and names 売上原価 when the cost-of-sales stage is missing', () => {
+    const details = missingDetails(stagesWithout('売上原価'))
+    expect(JSON.stringify(details)).toContain('売上原価')
+    expect(JSON.stringify(details)).not.toContain('売上高')
+  })
+
+  it('fails and names 販売管理費 when the SGA stage is missing', () => {
+    const details = missingDetails(stagesWithout('販売管理費'))
+    expect(JSON.stringify(details)).toContain('販売管理費')
+    expect(JSON.stringify(details)).not.toContain('営業利益')
+  })
+
+  it('still fails naming 営業利益 when the operating-income stage is missing', () => {
+    const details = missingDetails(stagesWithout('営業利益'))
+    expect(JSON.stringify(details)).toContain('営業利益')
+  })
+
+  it('lists all four required stages in the error code', () => {
+    const r = buildVarianceBridge({ stages: stagesWithout('売上高') })
+    expect(r.success).toBe(false)
+    if (r.success) return
+    expect(r.error.code).toBe('VALIDATION_ERROR')
+  })
+})

--- a/tests/unit/services/budget/variance-attribution-edge.test.ts
+++ b/tests/unit/services/budget/variance-attribution-edge.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest'
+import {
+  attributeVariance,
+  isPeriodBoundary,
+  type AttributionInput,
+  type AccountAttributionInput,
+  type JournalEntry,
+  type VarianceAttribution,
+} from '@/services/budget/variance-attribution'
+
+/**
+ * EDGE-01 — error / edge-case deepening for the variance-attribution pure core.
+ *
+ * These cases cover branches left uncovered by the golden suite
+ * (variance-attribution.test.ts): malformed period dates, a neutral-direction
+ * journal (deviation exactly 0), a null freeeJournalId, an sga-only input (no
+ * revenue/COGS to trigger the category-mapping warning), and the `mock`
+ * actuals-source synthetic-data warning.
+ *
+ * Every assertion checks a real computed value — no toBeDefined() cop-outs.
+ */
+
+const FY = 2025
+const MO = 6
+
+function expenseJournal(
+  id: string,
+  amount: number,
+  entryDate: string,
+  freeeJournalId: string | null = id
+): JournalEntry {
+  return {
+    journalId: id,
+    freeeJournalId,
+    entryDate,
+    description: '',
+    amount,
+    side: 'debit',
+  }
+}
+
+function run(input: AttributionInput): VarianceAttribution {
+  const result = attributeVariance(input)
+  if (!result.success) {
+    throw new Error(`attributeVariance failed: ${result.error.message}`)
+  }
+  return result.data
+}
+
+/** A revenue account that doubles as the materiality base (totalRevenue = actual). */
+function revenueAccount(
+  budget: number,
+  actual: number,
+  journals: JournalEntry[]
+): AccountAttributionInput {
+  return {
+    accountCode: '400',
+    accountName: '売上高',
+    category: 'revenue',
+    budget,
+    actual,
+    journals,
+  }
+}
+
+describe('isPeriodBoundary — malformed / non-numeric dates (§6.3)', () => {
+  it('returns false for a date with fewer than 3 dash-parts', () => {
+    expect(isPeriodBoundary('2025-06', FY, MO)).toBe(false) // 2 parts
+    expect(isPeriodBoundary('2025', FY, MO)).toBe(false) // 1 part
+    expect(isPeriodBoundary('', FY, MO)).toBe(false) // empty
+  })
+
+  it('returns false when the date parts are non-numeric', () => {
+    expect(isPeriodBoundary('abcd-ef-gh', FY, MO)).toBe(false)
+    expect(isPeriodBoundary('YYYY-MM-DD', FY, MO)).toBe(false)
+  })
+
+  it('still validates a well-formed boundary date after the malformed cases', () => {
+    expect(isPeriodBoundary('2025-06-01', FY, MO)).toBe(true)
+    expect(isPeriodBoundary('2025-06-30', FY, MO)).toBe(true)
+  })
+})
+
+describe('journal direction — neutral when deviation is exactly 0', () => {
+  it('tags a journal whose signed amount equals the M0 expected as neutral', () => {
+    // Revenue account, budget 100,000; 2 credit journals 50,000 + 75,000.
+    // expected = 100,000 / 2 = 50,000.
+    //   journal A (50,000): deviation 0 → neutral.
+    //   journal B (75,000): deviation +25,000, revenue → favorable.
+    // actual = 125,000; variance = 25,000; material (threshold 10,000).
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        revenueAccount(100000, 125000, [
+          {
+            journalId: 'a',
+            freeeJournalId: 'a',
+            entryDate: '2025-06-10',
+            description: '',
+            amount: 50000,
+            side: 'credit',
+          },
+          {
+            journalId: 'b',
+            freeeJournalId: 'b',
+            entryDate: '2025-06-15',
+            description: '',
+            amount: 75000,
+            side: 'credit',
+          },
+        ]),
+      ],
+    }).accounts[0]
+
+    const a = acc.journals.find((j) => j.journalId === 'a')!
+    const b = acc.journals.find((j) => j.journalId === 'b')!
+    expect(a.deviation).toBe(0)
+    expect(a.direction).toBe('neutral')
+    expect(b.deviation).toBe(25000)
+    expect(b.direction).toBe('favorable')
+  })
+})
+
+describe('null freeeJournalId is preserved as null', () => {
+  it('renders freeeJournalId null when the input journal omits/provides null', () => {
+    const acc = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        revenueAccount(10000000, 10000000, []),
+        {
+          accountCode: '600',
+          accountName: '給与手当',
+          category: 'sga_expense',
+          budget: 800000,
+          actual: 940000,
+          journals: [expenseJournal('j1', 940000, '2025-06-15', null)],
+        },
+      ],
+    }).accounts.find((a) => a.accountCode === '600')!
+
+    // The single 940,000 journal had freeeJournalId null → output preserves null.
+    expect(acc.journals).toHaveLength(1)
+    expect(acc.journals[0].freeeJournalId).toBeNull()
+  })
+})
+
+describe('data-quality warnings — sga-only input', () => {
+  it('omits the category-mapping warning when no revenue or COGS account is present', () => {
+    // Only an sga_expense account (material, variance 20,000 ≥ 10,000 floor with no revenue).
+    const out = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [
+        {
+          accountCode: '600',
+          accountName: '給与手当',
+          category: 'sga_expense',
+          budget: 100000,
+          actual: 120000,
+          journals: [expenseJournal('j', 120000, '2025-06-15')],
+        },
+      ],
+    })
+
+    expect(out.dataQuality.warnings).not.toContain('category_mapping_unverified_freee_path')
+    // The PVVM warning is always present (Journal stores no partner/segment/quantity).
+    expect(out.dataQuality.warnings).toContain('pvvm_not_computable_no_dimensions')
+  })
+})
+
+describe('data-quality warnings — synthetic actuals source', () => {
+  it('flags actualsSource mock with the actuals_are_synthetic warning', () => {
+    const out = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'mock',
+      accounts: [revenueAccount(10000000, 10000000, [])],
+    })
+
+    expect(out.dataQuality.actualsSource).toBe('mock')
+    expect(out.dataQuality.warnings).toContain('actuals_are_synthetic')
+  })
+
+  it('does not flag actuals_are_synthetic for monthly_balance source', () => {
+    const out = run({
+      fiscalYear: FY,
+      month: MO,
+      actualsSource: 'monthly_balance',
+      accounts: [revenueAccount(10000000, 10000000, [])],
+    })
+
+    expect(out.dataQuality.warnings).not.toContain('actuals_are_synthetic')
+  })
+})

--- a/tests/unit/services/budget/variance-attribution-loader-edge.test.ts
+++ b/tests/unit/services/budget/variance-attribution-loader-edge.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { ProfitLoss } from '@/types'
+import {
+  buildAccountResolver,
+  resolveJournalsToAccounts,
+  prepareAttributionInput,
+  computeVarianceAttribution,
+  type BudgetRow,
+  type JournalRow,
+  type AccountItemRow,
+} from '@/services/budget/variance-attribution-loader'
+
+/**
+ * EDGE-01 — error / edge-case deepening for the variance-attribution loader.
+ *
+ * Covers branches left uncovered by variance-attribution-loader.test.ts:
+ *   - inferCategoryFromType: income / cogs / expense hits (existing suite only
+ *     exercised balance-sheet types via actuals-shadowed items) and a null
+ *     categoryType (the `?? ''` fallback).
+ *   - AccountItem code fallback chain: shortcutNum → shortcut → String(freeeId).
+ *   - buildAccountResolver costOfSales loop (existing actuals had empty costOfSales).
+ *   - pushJournal: a second journal to the same account (the `existing` branch).
+ *   - prepareAttributionInput: costOfSales actuals, and a null-departmentId budget
+ *     excluded by the department scope filter.
+ *   - computeVarianceAttribution: non-integer fiscalYear (returns before any DB call).
+ *
+ * Only pure helpers + the pre-DB validation path are exercised, so the prisma /
+ * getBudgetsByMonth mocks are stubs that are never invoked.
+ */
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    journal: { findMany: vi.fn() },
+    accountItem: { findMany: vi.fn() },
+  },
+}))
+vi.mock('@/services/budget/budget-service', () => ({
+  getBudgetsByMonth: vi.fn(),
+}))
+
+const actuals: ProfitLoss = {
+  fiscalYear: 2025,
+  month: 6,
+  revenue: [{ code: '400', name: '売上高', amount: 10000000 }],
+  costOfSales: [{ code: '500', name: '売上原価', amount: 6000000 }],
+  grossProfit: 4000000,
+  grossProfitMargin: 40,
+  sgaExpenses: [{ code: '600', name: '給与手当', amount: 940000 }],
+  operatingIncome: 3060000,
+  operatingMargin: 30.6,
+  nonOperatingIncome: [],
+  nonOperatingExpenses: [],
+  ordinaryIncome: 3060000,
+  extraordinaryIncome: [],
+  extraordinaryLoss: [],
+  incomeBeforeTax: 3060000,
+  incomeTax: 918000,
+  netIncome: 2142000,
+  depreciation: 0,
+}
+
+describe('buildAccountResolver — AccountItem category-type inference & code fallbacks', () => {
+  // Each item has a name absent from actuals/budgets so the AccountItem loop
+  // actually runs inferCategoryFromType for it.
+  const accountItems: AccountItemRow[] = [
+    { name: '受取利息', shortcutNum: '410', shortcut: null, freeeId: 4100, categoryType: 'income' },
+    { name: '仕入', shortcutNum: null, shortcut: '510', freeeId: 5100, categoryType: 'cogs' },
+    { name: '消耗品費', shortcutNum: null, shortcut: null, freeeId: 6100, categoryType: 'expense' },
+    { name: '雑勘定', shortcutNum: null, shortcut: null, freeeId: 9900, categoryType: null },
+  ]
+  const resolver = buildAccountResolver({ actuals, budgets: [], accountItems })
+
+  it('infers revenue from categoryType income and uses shortcutNum as the code', () => {
+    expect(resolver('受取利息')).toEqual({
+      accountCode: '410',
+      accountName: '受取利息',
+      category: 'revenue',
+    })
+  })
+
+  it('infers cost_of_sales from categoryType cogs and falls back to shortcut', () => {
+    expect(resolver('仕入')).toEqual({
+      accountCode: '510',
+      accountName: '仕入',
+      category: 'cost_of_sales',
+    })
+  })
+
+  it('infers sga_expense from categoryType expense and falls back to String(freeeId)', () => {
+    expect(resolver('消耗品費')).toEqual({
+      accountCode: '6100',
+      accountName: '消耗品費',
+      category: 'sga_expense',
+    })
+  })
+
+  it('returns null when categoryType is null and the freeeId-derived code is non-P&L', () => {
+    // categoryType null → `?? ''` → empty string → falls through every type check →
+    // inferCategoryFromCode('9900') → null → not attributable.
+    expect(resolver('雑勘定')).toBeNull()
+  })
+
+  it('resolves a costOfSales actual through the costOfSales resolver loop', () => {
+    expect(resolver('売上原価')).toEqual({
+      accountCode: '500',
+      accountName: '売上原価',
+      category: 'cost_of_sales',
+    })
+  })
+})
+
+describe('resolveJournalsToAccounts — multiple journals to one account', () => {
+  it('accumulates two journals debiting the same account into one group', () => {
+    const resolver = buildAccountResolver({ actuals, budgets: [], accountItems: [] })
+    const journals: JournalRow[] = [
+      {
+        id: 'j1',
+        freeeJournalId: 'fj1',
+        entryDate: new Date('2025-06-10T00:00:00.000Z'),
+        description: 'pay1',
+        debitAccount: '給与手当',
+        creditAccount: '現金',
+        amount: 500000,
+      },
+      {
+        id: 'j2',
+        freeeJournalId: 'fj2',
+        entryDate: new Date('2025-06-15T00:00:00.000Z'),
+        description: 'pay2',
+        debitAccount: '給与手当',
+        creditAccount: '現金',
+        amount: 440000,
+      },
+    ]
+    const { byAccount } = resolveJournalsToAccounts({
+      journals,
+      resolver,
+      fiscalYear: 2025,
+      month: 6,
+    })
+    const pay = byAccount.get('600')!
+    expect(pay.journals).toHaveLength(2)
+    expect(pay.journals.map((j) => j.journalId)).toEqual(['j1', 'j2'])
+  })
+})
+
+describe('prepareAttributionInput — costOfSales actuals & department scope', () => {
+  it('includes costOfSales accounts from actuals in the attribution input', () => {
+    const input = prepareAttributionInput({
+      actuals,
+      budgets: [],
+      journals: [],
+      fiscalYear: 2025,
+      month: 6,
+    })
+    const cogs = input.accounts.find((a) => a.accountCode === '500')!
+    expect(cogs.category).toBe('cost_of_sales')
+    expect(cogs.actual).toBe(6000000)
+  })
+
+  it('excludes a null-departmentId budget when scoping to a specific department', () => {
+    const budgets: BudgetRow[] = [
+      { accountCode: '600', accountName: '給与手当', amount: 500000, departmentId: null },
+      { accountCode: '600', accountName: '給与手当', amount: 300000, departmentId: 'dept-A' },
+    ]
+    const scoped = prepareAttributionInput({
+      actuals,
+      budgets,
+      journals: [],
+      fiscalYear: 2025,
+      month: 6,
+      departmentId: 'dept-A',
+    })
+    // The null-departmentId row is filtered out (null ?? '' === 'dept-A' is false);
+    // only the dept-A row (300,000) is summed.
+    expect(scoped.accounts.find((a) => a.accountCode === '600')!.budget).toBe(300000)
+  })
+})
+
+describe('computeVarianceAttribution — non-integer fiscalYear', () => {
+  it('returns VALIDATION_ERROR before any DB access', async () => {
+    const result = await computeVarianceAttribution({
+      companyId: 'company-1',
+      fiscalYear: 2025.5,
+      month: 6,
+      actuals,
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.code).toBe('VALIDATION_ERROR')
+    }
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> Risk class C — standard PR review.

## Auto-generated PR — task `edge-01`

**Risk class:** `C`
**Title:** Deepen error/edge-case tests in analytics + budget services

### Files declared in task
- src/services/analytics
- src/services/budget
- tests/unit/services

### Files actually changed (7)
- docs/auto-sessions/edge-01/summary.md
- tests/unit/services/analytics/managerial-accounting-edge.test.ts
- tests/unit/services/budget/budget-import-edge.test.ts
- tests/unit/services/budget/detailed-actual-vs-budget-edge.test.ts
- tests/unit/services/budget/managerial-accounting-edge.test.ts
- tests/unit/services/budget/variance-attribution-edge.test.ts
- tests/unit/services/budget/variance-attribution-loader-edge.test.ts


### Subagents declared
_(none)_

### Commit
`auto(C): Deepen error/edge-case tests in analytics + budget services`

### Required human review
- [ ] Compliance review
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._