### PR TITLE
[auto/C] auto(C): Deepen error/edge-case tests in report/reports/cashflow services

### DIFF
--- a/docs/auto-sessions/edge-02/summary.md
+++ b/docs/auto-sessions/edge-02/summary.md
@@ -1,0 +1,39 @@
+# EDGE-02 — Deepen error/edge-case tests in report/reports/cashflow services
+
+## Scope
+Additive edge-case tests for the non-Class-A report / reports / cashflow services.
+No production source was modified — all changes are new `*-edge.test.ts` files that
+pin previously-uncovered branches and a few latent defects (documented, not fixed).
+
+## Files added (4 test files, 47 tests)
+| File | Target source | What it newly covers |
+|------|---------------|----------------------|
+| `tests/unit/services/cashflow/runway-calculator-edge.test.ts` | `src/services/cashflow/runway-calculator.ts` | **`computeRunwayMonths` direct tests** (exported, previously untested): non-finite cash → `Infinity`, `avgNetBurn ≤ 0` / non-finite → `Infinity`, normal/negative/zero division. `getRunwayAlert` sub-threshold boundaries (just below 12 / 6 / 3, `Infinity`). `calculateBurnRateTrend` `previousBurn === 0` stable branch + partial previous-slice (5-month window). |
+| `tests/unit/services/reports/business-report/content-validator-edge.test.ts` | `src/services/reports/business-report/content-validator.ts` | Exact `minLength`/`maxLength` boundaries (at-boundary valid, +1 char over → error). Placeholder `> 3` threshold boundary (3 = no warn, 4 = warn, for both `〇〇` and `{{…}}`). `calculateConfidence` exact `1.0` / floor `0` / `0.05`-per-placeholder penalty. `checkLegalTerminology.missing` (always `[]`). `validateCompleteReport` whitespace-only-is-missing, exact `completeness` math (12.5 %), and warning text. |
+| `tests/unit/services/report/monthly-report-edge.test.ts` | `src/services/report/monthly-report.ts` | Drives `getMonthlyTrend` + `getMultiMonthReport` with **real `MonthlyBalance` rows** so `mapBalancesToProfitLoss` / `mapBalancesToBalanceSheet` execute (the existing test feeds `[]` and mocks every dependency, leaving these helpers dead). Exact P&L chain (revenue→grossProfit→operatingIncome→`round(op*0.7)` netIncome), category non-leakage, sample fallback. `getMultiMonthReport` year-boundary month wrap (`endMonth=2,count=3 → [12,1,2]`), non-wrap, full-12 wrap, `NOT_FOUND`, and real-data section construction. |
+| `tests/unit/services/report/periodic-report-edge.test.ts` | `src/services/report/periodic-report.ts` | Drives `generatePeriodicReport` with **real balances** (pinned `now` via fake timers) so `mapToPeriodBS` / `calculatePeriodPL` / `calculatePeriodCF` / `calculatePeriodKPIs` / `generateSummary` / `generateTrendAnalysis` execute (existing test feeds `[]` → `Math.random` sample path). Exact first-period BS/PL/CF(no-previous-month branch)/KPI(2-dp round) values, summary growth + all-stable trend, and the all-zero-denominator case exercising **every KPI zero-guard** + null-growth + cash-caution trend. |
+
+## Notes / latent defects pinned (characterization, not fixed — out of EDGE-02 scope)
+- `mapBalancesToProfitLoss` (`monthly-report.ts`) computes
+  `grossProfitMargin = (grossProfit / totalRevenue) * 100` and
+  `operatingMargin = (operatingIncome / totalRevenue) * 100` with **no zero-revenue
+  guard**. When recorded balances have no `revenue` category, `totalRevenue === 0` and
+  the margins become `NaN`/`-Infinity`. (The periodic-report counterpart
+  `calculatePeriodKPIs` *does* guard with `pl.revenue > 0`.) Not assert-pinned here to
+  avoid coupling to `generateMonthlyReport`'s 5 mocked dependencies; flagged for a
+  future fix task. See memory `cashflow-subsystem-scenario-gaps` /
+  `budget-variance-actuals-lineage-broken` for the broader P&L-source context.
+- `checkLegalTerminology` always returns `missing: []` (the field is unused). Pinned as
+  current behavior.
+
+## Verification
+- `pnpm exec vitest run <4 files>` → **47 passed**.
+- `pnpm exec eslint --max-warnings=0 <4 files>` → exit 0.
+- `node scripts/autopm_verify.mjs --changed-only` → exit 0 (definition of done).
+
+## Constraints honored
+- No Class-A path touched (read-only reference only).
+- No `any` / `@ts-ignore` / `.skip` / lint-disable / threshold lowering. No new deps.
+- New helpers follow `Result<T,E>` + Zod `safeParse` where the SUT uses them; these are
+  pure-function test files so no new helpers were needed.
+- Only the added test files were run (known full-suite OOM avoided).

--- a/tests/unit/services/cashflow/runway-calculator-edge.test.ts
+++ b/tests/unit/services/cashflow/runway-calculator-edge.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from 'vitest'
+import {
+  computeRunwayMonths,
+  getRunwayAlert,
+  calculateBurnRateTrend,
+} from '@/services/cashflow/runway-calculator'
+import type { CashFlowStatement } from '@/types'
+
+describe('computeRunwayMonths', () => {
+  it('divides cash by net burn on the happy path', () => {
+    expect(computeRunwayMonths(1000, 100)).toBe(10)
+    expect(computeRunwayMonths(5000000, 1000000)).toBe(5)
+  })
+
+  it('returns 0 when there is no cash left but a positive burn', () => {
+    expect(computeRunwayMonths(0, 500)).toBe(0)
+  })
+
+  it('returns a negative runway when cash is overdrawn', () => {
+    expect(computeRunwayMonths(-300, 100)).toBe(-3)
+  })
+
+  it('returns Infinity for a non-finite cash balance (NaN)', () => {
+    expect(computeRunwayMonths(Number.NaN, 100)).toBe(Infinity)
+  })
+
+  it('returns Infinity for a non-finite cash balance (Infinity)', () => {
+    expect(computeRunwayMonths(Number.POSITIVE_INFINITY, 100)).toBe(Infinity)
+  })
+
+  it('returns Infinity when the burn rate is zero (not burning)', () => {
+    expect(computeRunwayMonths(1000, 0)).toBe(Infinity)
+  })
+
+  it('returns Infinity when the burn rate is negative (cash-positive)', () => {
+    expect(computeRunwayMonths(1000, -250)).toBe(Infinity)
+  })
+
+  it('returns Infinity for a NaN burn rate', () => {
+    expect(computeRunwayMonths(1000, Number.NaN)).toBe(Infinity)
+  })
+
+  it('returns Infinity for an infinite burn rate', () => {
+    expect(computeRunwayMonths(1000, Number.POSITIVE_INFINITY)).toBe(Infinity)
+  })
+
+  it('prefers the cash-finiteness guard over the burn guard', () => {
+    expect(computeRunwayMonths(Number.NaN, Number.NaN)).toBe(Infinity)
+  })
+})
+
+describe('getRunwayAlert (sub-threshold boundaries)', () => {
+  it('is warning just below the 12-month safe threshold', () => {
+    const result = getRunwayAlert(11.9)
+    expect(result.level).toBe('warning')
+    expect(result.message).toContain('注意')
+  })
+
+  it('is critical (危険) just below the 6-month warning threshold', () => {
+    const result = getRunwayAlert(5.9)
+    expect(result.level).toBe('critical')
+    expect(result.message).toContain('危険')
+    expect(result.message).not.toContain('ショート')
+  })
+
+  it('is critical (ショート) just below the 3-month threshold', () => {
+    const result = getRunwayAlert(2.9)
+    expect(result.level).toBe('critical')
+    expect(result.message).toContain('ショート')
+  })
+
+  it('treats an infinite runway as safe', () => {
+    const result = getRunwayAlert(Number.POSITIVE_INFINITY)
+    expect(result.level).toBe('safe')
+  })
+
+  it('treats a fractional runway just over 12 as safe', () => {
+    expect(getRunwayAlert(12.01).level).toBe('safe')
+  })
+})
+
+describe('calculateBurnRateTrend (previous-period edge cases)', () => {
+  const cf = (month: number, netCash: number): CashFlowStatement => ({
+    fiscalYear: 2024,
+    month,
+    operatingActivities: {
+      netCashFromOperating: netCash,
+      netIncome: 0,
+      depreciation: 0,
+      amortization: 0,
+      deferredTaxChange: 0,
+      increaseInReceivables: 0,
+      decreaseInInventory: 0,
+      increaseInPayables: 0,
+      otherNonCash: 0,
+    },
+    investingActivities: {
+      netCashFromInvesting: 0,
+      purchaseOfFixedAssets: 0,
+      saleOfFixedAssets: 0,
+    },
+    financingActivities: {
+      netCashFromFinancing: 0,
+      proceedsFromBorrowing: 0,
+      repaymentOfBorrowing: 0,
+      dividendPaid: 0,
+      interestPaid: 0,
+    },
+    netChangeInCash: netCash,
+    beginningCash: 0,
+    endingCash: 0,
+  })
+
+  it('is stable with rate 0 when the previous window did not burn', () => {
+    const cashFlows = [
+      cf(1, 500000),
+      cf(2, 400000),
+      cf(3, 300000),
+      cf(4, -1000000),
+      cf(5, -1200000),
+      cf(6, -1500000),
+    ]
+    const result = calculateBurnRateTrend(cashFlows)
+    expect(result.trend).toBe('stable')
+    expect(result.rate).toBe(0)
+  })
+
+  it('detects an increasing trend from a 5-month window (partial previous slice)', () => {
+    const cashFlows = [
+      cf(1, -100000),
+      cf(2, -120000),
+      cf(3, -400000),
+      cf(4, -500000),
+      cf(5, -600000),
+    ]
+    const result = calculateBurnRateTrend(cashFlows)
+    expect(result.trend).toBe('increasing')
+    expect(result.rate).toBeGreaterThan(10)
+  })
+
+  it('is stable when both windows burn at the same rate', () => {
+    const cashFlows = [
+      cf(1, -500000),
+      cf(2, -500000),
+      cf(3, -500000),
+      cf(4, -500000),
+      cf(5, -500000),
+      cf(6, -500000),
+    ]
+    const result = calculateBurnRateTrend(cashFlows)
+    expect(result.trend).toBe('stable')
+    expect(result.rate).toBe(0)
+  })
+})

--- a/tests/unit/services/report/monthly-report-edge.test.ts
+++ b/tests/unit/services/report/monthly-report-edge.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { getMonthlyTrend, getMultiMonthReport } from '@/services/report/monthly-report'
+import { clearBalanceCache } from '@/services/report/balance-loader'
+import { prisma } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    company: { findFirst: vi.fn() },
+    monthlyBalance: { findMany: vi.fn() },
+  },
+}))
+
+const company = { id: 'co-1', name: 'テスト株式会社' }
+
+function row(
+  month: number,
+  category: string,
+  accountCode: string,
+  accountName: string,
+  amount: number
+) {
+  return {
+    id: `${accountCode}-${month}`,
+    companyId: 'co-1',
+    fiscalYear: 2024,
+    month,
+    accountCode,
+    accountName,
+    category,
+    amount,
+  }
+}
+
+const month1Balances = [
+  row(1, 'revenue', '4000', '売上高', 1000),
+  row(1, 'cost_of_sales', '5000', '売上原価', 400),
+  row(1, 'sga_expense', '6100', '減価償却費', 100),
+  row(1, 'sga_expense', '6200', '管理部門人件費', 50),
+  row(1, 'current_asset', '1000', '現金及び預金', 5000),
+  row(1, 'fixed_asset', '2000', '建物', 8000),
+]
+
+describe('monthly-report real-balance mapping (edge cases)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearBalanceCache()
+    vi.mocked(prisma.company.findFirst).mockResolvedValue(company as never)
+    vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue([] as never)
+  })
+
+  describe('getMonthlyTrend — mapBalancesToProfitLoss / mapBalancesToBalanceSheet', () => {
+    it('maps recorded balances into exact P&L and cash figures for the recorded month', async () => {
+      vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(month1Balances as never)
+
+      const trends = await getMonthlyTrend('co-1', 2024)
+
+      expect(trends).toHaveLength(12)
+      const jan = trends[0]
+      expect(jan.month).toBe('1月')
+      // revenue aggregates only the 'revenue' category
+      expect(jan.revenue).toBe(1000)
+      // grossProfit = revenue(1000) - costOfSales(400)
+      expect(jan.grossProfit).toBe(600)
+      // operatingIncome = grossProfit(600) - sga(100+50)
+      expect(jan.operatingIncome).toBe(450)
+      // netIncome = round(operatingIncome * 0.7)
+      expect(jan.netIncome).toBe(315)
+      // cash = first current_asset amount
+      expect(jan.cash).toBe(5000)
+    })
+
+    it('ignores balance categories that do not belong to the P&L (no leakage)', async () => {
+      const withExtra = [
+        ...month1Balances,
+        row(1, 'current_liability', '3000', '買掛金', 9999),
+        row(1, 'equity', '5000', '資本金', 9999),
+      ]
+      vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(withExtra as never)
+
+      const [jan] = await getMonthlyTrend('co-1', 2024)
+      // liabilities/equity must not inflate revenue or gross profit
+      expect(jan.revenue).toBe(1000)
+      expect(jan.grossProfit).toBe(600)
+    })
+
+    it('extracts depreciation only from SGA items whose name contains 減価償却', async () => {
+      vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(month1Balances as never)
+
+      // Indirect check: netIncome uses operatingIncome (which already deducts full SGA),
+      // and operatingIncome is unaffected by which SGA line is depreciation — but the
+      // presence of a depreciation line must not double-count. Pin operatingIncome.
+      const [jan] = await getMonthlyTrend('co-1', 2024)
+      expect(jan.operatingIncome).toBe(450)
+    })
+
+    it('falls back to sample data for months that have no recorded balances', async () => {
+      vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(month1Balances as never)
+
+      const trends = await getMonthlyTrend('co-1', 2024)
+      // Month 1 is recorded (revenue 1000); month 2 has no balances and must still
+      // produce a finite, non-undefined trend entry derived from sample data.
+      expect(trends[1].month).toBe('2月')
+      expect(Number.isFinite(trends[1].revenue)).toBe(true)
+      expect(trends[1].revenue).not.toBe(1000)
+      expect(Number.isFinite(trends[1].cash)).toBe(true)
+    })
+  })
+
+  describe('getMultiMonthReport — window construction', () => {
+    it('wraps months across the year boundary (endMonth=2, count=3 → [12,1,2])', async () => {
+      const result = await getMultiMonthReport('co-1', 2024, 2, 3)
+
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(result.data.months).toEqual([12, 1, 2])
+      expect(result.data.monthCount).toBe(3)
+      expect(result.data.endMonth).toBe(2)
+    })
+
+    it('does not wrap when the window fits inside the year (endMonth=6, count=3 → [4,5,6])', async () => {
+      const result = await getMultiMonthReport('co-1', 2024, 6, 3)
+
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(result.data.months).toEqual([4, 5, 6])
+    })
+
+    it('wraps the full 12-month window ending at month 1 (→ [2..12,1])', async () => {
+      const result = await getMultiMonthReport('co-1', 2024, 1, 12)
+
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      expect(result.data.months[0]).toBe(2)
+      expect(result.data.months[11]).toBe(1)
+      expect(result.data.months).toHaveLength(12)
+    })
+
+    it('returns NOT_FOUND when the company does not exist', async () => {
+      vi.mocked(prisma.company.findFirst).mockResolvedValue(null as never)
+
+      const result = await getMultiMonthReport('missing', 2024, 12, 3)
+
+      expect(result.success).toBe(false)
+      if (result.success) return
+      expect(result.error.code).toBe('NOT_FOUND')
+      expect(result.error.message).toBe('Company not found')
+    })
+
+    it('builds all four section types from recorded balances', async () => {
+      const balances = [
+        row(12, 'current_asset', '1000', '現金及び預金', 5000),
+        row(12, 'revenue', '4000', '売上高', 1000),
+        row(12, 'cost_of_sales', '5000', '売上原価', 400),
+        row(12, 'sga_expense', '6100', '減価償却費', 100),
+      ]
+      vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(balances as never)
+
+      const result = await getMultiMonthReport('co-1', 2024, 12, 3)
+
+      expect(result.success).toBe(true)
+      if (!result.success) return
+      const types = result.data.sections.map((s) => s.type)
+      expect(types).toEqual(['bs', 'pl', 'cf', 'kpi'])
+      // BS section must contain the asset total row driven by recorded balances
+      const bs = result.data.sections.find((s) => s.type === 'bs')
+      expect(bs?.rows.some((r) => r.name === '資産合計')).toBe(true)
+    })
+  })
+})

--- a/tests/unit/services/report/periodic-report-edge.test.ts
+++ b/tests/unit/services/report/periodic-report-edge.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { generatePeriodicReport } from '@/services/report/periodic-report'
+import { clearBalanceCache } from '@/services/report/balance-loader'
+import { prisma } from '@/lib/db'
+
+vi.mock('@/lib/db', () => ({
+  prisma: {
+    monthlyBalance: { findMany: vi.fn() },
+  },
+}))
+
+// Pinned "now": 2024-04-15. With fiscalYearEndMonth=3, currentMonth(4) > 3, so the
+// 3-month window is [month 2, month 3, month 4] of fiscal year 2024.
+const PINNED_NOW = new Date('2024-04-15T12:00:00')
+
+function prow(month: number, category: string, accountCode: string, amount: number) {
+  return {
+    id: `${accountCode}-${month}`,
+    companyId: 'co-1',
+    fiscalYear: 2024,
+    month,
+    accountCode,
+    accountName: category,
+    category,
+    amount,
+  }
+}
+
+// Period categories use the PLURAL forms (current_assets, sales, ...) — distinct
+// from monthly-report's singular forms.
+function fullPeriodBalances(
+  month: number,
+  sales: number,
+  cogs: number,
+  cash: number,
+  equity: number
+) {
+  return [
+    prow(month, 'sales', '4000', sales),
+    prow(month, 'cost_of_sales', '5000', cogs),
+    prow(month, 'sga_expenses', '6100', 200),
+    prow(month, 'non_operating_income', '7000', 50),
+    prow(month, 'non_operating_expenses', '7100', 20),
+    prow(month, 'current_assets', '1000', cash),
+    prow(month, 'fixed_assets', '2000', 3000),
+    prow(month, 'current_liabilities', '3000', 1000),
+    prow(month, 'fixed_liabilities', '4000', 500),
+    prow(month, 'net_assets', '5000', equity),
+  ]
+}
+
+describe('generatePeriodicReport — real-balance mapping (edge cases)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearBalanceCache()
+    vi.useFakeTimers()
+    vi.setSystemTime(PINNED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('maps recorded balances into exact BS/PL/CF/KPI figures for the first period', async () => {
+    const balances = [
+      ...fullPeriodBalances(2, 1000, 400, 5000, 6000),
+      ...fullPeriodBalances(3, 1100, 440, 5200, 6200),
+      ...fullPeriodBalances(4, 1200, 480, 5400, 6400),
+    ]
+    vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(balances as never)
+
+    const result = await generatePeriodicReport({
+      companyId: 'co-1',
+      fiscalYearEndMonth: 3,
+      periodType: '3months',
+      includePreviousYear: false,
+    })
+
+    expect(result.periods).toHaveLength(3)
+    const first = result.periods[0]
+    expect(first.endMonth).toBe(2)
+
+    // BS — totals aggregate the plural category buckets
+    expect(first.balanceSheet).toEqual({
+      totalAssets: 8000,
+      currentAssets: 5000,
+      fixedAssets: 3000,
+      totalLiabilities: 1500,
+      currentLiabilities: 1000,
+      fixedLiabilities: 500,
+      equity: 6000,
+    })
+
+    // PL — full indirect chain down to net income (no tax/special -> netIncome = ordinary)
+    expect(first.profitLoss).toEqual({
+      revenue: 1000,
+      costOfSales: 400,
+      grossProfit: 600,
+      operatingIncome: 400,
+      ordinaryIncome: 430,
+      netIncome: 430,
+    })
+
+    // CF — first period has no previous month recorded → falls back to netIncome only
+    expect(first.cashFlow).toEqual({
+      operatingCF: 430,
+      investingCF: 0,
+      financingCF: 0,
+      freeCashFlow: 430,
+    })
+    expect(first.endingCash).toBe(5000)
+
+    // KPIs — rounded to 2 decimals
+    expect(first.kpis).toEqual({
+      roe: 7.17,
+      roa: 5.38,
+      grossMargin: 60,
+      operatingMargin: 40,
+      currentRatio: 500,
+      debtToEquity: 0.25,
+    })
+  })
+
+  it('computes summary growth, cash change and the all-stable trend string', async () => {
+    const balances = [
+      ...fullPeriodBalances(2, 1000, 400, 5000, 6000),
+      ...fullPeriodBalances(3, 1100, 440, 5200, 6200),
+      ...fullPeriodBalances(4, 1200, 480, 5400, 6400),
+    ]
+    vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(balances as never)
+
+    const result = await generatePeriodicReport({
+      companyId: 'co-1',
+      fiscalYearEndMonth: 3,
+      periodType: '3months',
+      includePreviousYear: false,
+    })
+
+    const summary = result.summary
+    // first.revenue=1000, last.revenue=1200 → +20%
+    expect(summary.revenueGrowth).toBe(20)
+    // first.netIncome=430, last.netIncome=550 → +27.91%
+    expect(summary.profitGrowth).toBe(27.91)
+    // last.cash(5400) - first.cash(5000)
+    expect(summary.cashChange).toBe(400)
+    expect(Number.isFinite(summary.avgROE)).toBe(true)
+    expect(summary.avgROE).toBeGreaterThan(0)
+    expect(summary.trendAnalysis).toBe('売上・利益・キャッシュ全てが安定して成長しています')
+  })
+
+  it('returns null growth and the cash-caution trend when every denominator is zero', async () => {
+    // One zero-amount sales row per month → all BS/PL buckets are 0, exercising every
+    // KPI zero-guard (equity, totalAssets, revenue, currentLiabilities all 0).
+    const balances = [
+      prow(2, 'sales', '4000', 0),
+      prow(3, 'sales', '4000', 0),
+      prow(4, 'sales', '4000', 0),
+    ]
+    vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue(balances as never)
+
+    const result = await generatePeriodicReport({
+      companyId: 'co-1',
+      fiscalYearEndMonth: 3,
+      periodType: '3months',
+      includePreviousYear: false,
+    })
+
+    const first = result.periods[0]
+    expect(first.kpis).toEqual({
+      roe: 0,
+      roa: 0,
+      grossMargin: 0,
+      operatingMargin: 0,
+      currentRatio: 0,
+      debtToEquity: 0,
+    })
+
+    const summary = result.summary
+    expect(summary.revenueGrowth).toBeNull()
+    expect(summary.profitGrowth).toBeNull()
+    expect(summary.cashChange).toBe(0)
+    // revenue flat (0>=0) and profit non-negative, but cash is 0 (not >0)
+    expect(summary.trendAnalysis).toBe(
+      '売上・利益は安定していますが、キャッシュフローに注意が必要です'
+    )
+  })
+
+  it('still serves periods when balances are absent (sample fallback path runs)', async () => {
+    vi.mocked(prisma.monthlyBalance.findMany).mockResolvedValue([] as never)
+
+    const result = await generatePeriodicReport({
+      companyId: 'co-1',
+      fiscalYearEndMonth: 3,
+      periodType: '3months',
+      includePreviousYear: false,
+    })
+
+    // Sample fallback must still produce 3 finite periods and a summary
+    expect(result.periods).toHaveLength(3)
+    for (const period of result.periods) {
+      expect(Number.isFinite(period.balanceSheet.totalAssets)).toBe(true)
+      expect(Number.isFinite(period.profitLoss.netIncome)).toBe(true)
+    }
+    expect(result.summary.trendAnalysis.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/services/reports/business-report/content-validator-edge.test.ts
+++ b/tests/unit/services/reports/business-report/content-validator-edge.test.ts
@@ -1,0 +1,140 @@
+import {
+  validateGeneratedContent,
+  calculateConfidence,
+  checkLegalTerminology,
+  validateCompleteReport,
+} from '@/services/reports/business-report/content-validator'
+
+describe('validateGeneratedContent (exact boundaries)', () => {
+  describe('minLength boundary (auditor.opinion: min 50, no keywords/patterns)', () => {
+    it('passes with no warnings when content length equals minLength', () => {
+      const result = validateGeneratedContent('auditor.opinion', 'a'.repeat(50))
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+      expect(result.warnings).toHaveLength(0)
+    })
+
+    it('warns on short content one char below minLength', () => {
+      const result = validateGeneratedContent('auditor.opinion', 'a'.repeat(49))
+      expect(result.isValid).toBe(true)
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].message).toContain('文字数が不足')
+    })
+  })
+
+  describe('maxLength boundary (auditor.opinion: max 5000)', () => {
+    it('stays valid when content length equals maxLength', () => {
+      const result = validateGeneratedContent('auditor.opinion', 'a'.repeat(5000))
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toHaveLength(0)
+    })
+
+    it('errors exactly one char over maxLength', () => {
+      const result = validateGeneratedContent('auditor.opinion', 'a'.repeat(5001))
+      expect(result.isValid).toBe(false)
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].code).toBe('CONTENT_TOO_LONG')
+      expect(result.errors[0].message).toContain('5001')
+      expect(result.errors[0].message).toContain('5000')
+    })
+  })
+
+  describe('placeholder threshold (productionOrders: maxLength only)', () => {
+    it('does not warn when exactly 3 〇〇 placeholders are present (boundary)', () => {
+      const result = validateGeneratedContent('companyStatus.productionOrders', '〇〇'.repeat(3))
+      expect(result.isValid).toBe(true)
+      expect(result.warnings).toHaveLength(0)
+    })
+
+    it('warns when a 4th 〇〇 placeholder appears', () => {
+      const result = validateGeneratedContent('companyStatus.productionOrders', '〇〇'.repeat(4))
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].message).toContain('プレースホルダー')
+    })
+
+    it('warns when a 4th {{...}} placeholder appears', () => {
+      const result = validateGeneratedContent(
+        'companyStatus.productionOrders',
+        '{{a}}{{b}}{{c}}{{d}}'
+      )
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].message).toContain('プレースホルダー')
+    })
+  })
+})
+
+describe('calculateConfidence (penalty math)', () => {
+  it('is exactly 1.0 for clean content with source data', () => {
+    const confidence = calculateConfidence('auditor.opinion', 'a'.repeat(60), true)
+    expect(confidence).toBe(1)
+  })
+
+  it('is clamped to 0 for maximally degraded content', () => {
+    const confidence = calculateConfidence(
+      'companyStatus.businessPerformance',
+      '〇〇△△[]'.repeat(20),
+      false
+    )
+    expect(confidence).toBe(0)
+  })
+
+  it('deducts 0.05 per [] placeholder (calculateConfidence-only pattern)', () => {
+    const clean = calculateConfidence('auditor.opinion', 'a'.repeat(60), true)
+    const withPlaceholders = calculateConfidence(
+      'auditor.opinion',
+      '[]'.repeat(2) + 'a'.repeat(60),
+      true
+    )
+    expect(clean).toBe(1)
+    expect(withPlaceholders).toBe(0.9)
+  })
+
+  it('never exceeds 1.0 even with no penalties', () => {
+    expect(calculateConfidence('auditor.opinion', 'a'.repeat(60), true)).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('checkLegalTerminology', () => {
+  it('always returns an empty missing array (field is currently unused)', () => {
+    const result = checkLegalTerminology('取締役会と貸借対照表について説明します。')
+    expect(result.used).toContain('取締役会')
+    expect(result.used).toContain('貸借対照表')
+    expect(result.missing).toEqual([])
+  })
+
+  it('returns empty used and missing arrays when no legal terms appear', () => {
+    const result = checkLegalTerminology('nothing legal here at all')
+    expect(result.used).toEqual([])
+    expect(result.missing).toEqual([])
+  })
+})
+
+describe('validateCompleteReport (completeness math)', () => {
+  it('treats whitespace-only content as missing even when raw length >= 50', () => {
+    const result = validateCompleteReport({
+      'companyStatus.businessDescription': '   '.repeat(20),
+    })
+    expect(result.isValid).toBe(false)
+    expect(result.completeness).toBe(0)
+    expect(result.missingSections).toContain('companyStatus.businessDescription')
+    expect(result.warnings).toContain('必須セクションの100%が未入力です')
+  })
+
+  it('computes completeness as filledCount/requiredCount*100', () => {
+    const result = validateCompleteReport({
+      'officers.directors': 'a'.repeat(60),
+    })
+    expect(result.isValid).toBe(false)
+    expect(result.completeness).toBe(12.5)
+    expect(result.missingSections).toHaveLength(7)
+    expect(result.warnings).toContain('必須セクションの87.5%が未入力です')
+  })
+
+  it('counts a section filled with exactly 50 non-space chars as complete', () => {
+    const result = validateCompleteReport({
+      'companyStatus.businessDescription': 'a'.repeat(50),
+    })
+    expect(result.completeness).toBe(12.5)
+    expect(result.missingSections).not.toContain('companyStatus.businessDescription')
+  })
+})


### PR DESCRIPTION
> [!NOTE]
> Risk class C — standard PR review.

## Auto-generated PR — task `edge-02`

**Risk class:** `C`
**Title:** Deepen error/edge-case tests in report/reports/cashflow services

### Files declared in task
- src/services/report
- src/services/reports
- src/services/cashflow
- tests/unit/services

### Files actually changed (5)
- docs/auto-sessions/edge-02/summary.md
- tests/unit/services/cashflow/runway-calculator-edge.test.ts
- tests/unit/services/report/monthly-report-edge.test.ts
- tests/unit/services/report/periodic-report-edge.test.ts
- tests/unit/services/reports/business-report/content-validator-edge.test.ts


### Subagents declared
_(none)_

### Commit
`auto(C): Deepen error/edge-case tests in report/reports/cashflow services`

### Required human review
- [ ] Compliance review
- [ ] CI green

---
_Generated by `tools/pm/agv_pm.py`. Auto-merge is disabled (`policy.auto_merge: false`) — every PR requires explicit human approval._